### PR TITLE
KOGITO-3035 add UPDATE_STABLE  param to runtimes

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -28,7 +28,7 @@ pipeline {
 
     parameters {
         string(name: 'PROJECT_VERSION', defaultValue: '', description: 'Project version to release as Major.minor.micro')
-        booleanParam(name: 'DEPLOY_IMAGES_WITH_LATEST', defaultValue: 'false', description: 'Deploy images with `latest` tag')
+        booleanParam(name: 'DEPLOY_AS_LATEST', defaultValue: 'false', description: 'Given project version is considered the latest version')
 
         booleanParam(name: 'SKIP_TESTS', defaultValue: false, description: 'Skip all tests')
 
@@ -217,6 +217,7 @@ pipeline {
 
                     def buildParams = getDefaultBuildParams()
                     addStringParam(buildParams, 'DEPLOY_BUILD_URL', getJobUrl(RUNTIMES_DEPLOY))
+                    addBooleanParam(buildParams, 'UPDATE_STABLE_BRANCH', params.DEPLOY_AS_LATEST)
 
                     buildJob(RUNTIMES_PROMOTE, buildParams)
                 }
@@ -234,10 +235,7 @@ pipeline {
                     def buildParams = getDefaultBuildParams()
                     addStringParam(buildParams, 'DEPLOY_BUILD_URL', getJobUrl(IMAGES_DEPLOY))
                     addImageBuildParams(buildParams, 'PROMOTE', env.IMAGE_PROMOTE_TAG, true, true)
-
-                    if(params.DEPLOY_IMAGES_WITH_LATEST){
-                        addBooleanParam(buildParams, 'DEPLOY_WITH_LATEST_TAG', true)
-                    }
+                    addBooleanParam(buildParams, 'DEPLOY_WITH_LATEST_TAG', params.DEPLOY_AS_LATEST)
 
                     buildJob(IMAGES_PROMOTE, buildParams)
                 }
@@ -255,10 +253,7 @@ pipeline {
                     def buildParams = getDefaultBuildParams()
                     addStringParam(buildParams, 'DEPLOY_BUILD_URL', getJobUrl(OPERATOR_DEPLOY))
                     addImageBuildParams(buildParams, 'PROMOTE', env.IMAGE_PROMOTE_TAG, true, true)
-
-                    if(params.DEPLOY_IMAGES_WITH_LATEST){
-                        addBooleanParam(buildParams, 'DEPLOY_WITH_LATEST_TAG', true)
-                    }
+                    addBooleanParam(buildParams, 'DEPLOY_WITH_LATEST_TAG', params.DEPLOY_AS_LATEST)
 
                     buildJob(OPERATOR_PROMOTE, buildParams)
                 }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-3035

So that the default branch is moved only for `latest` version (goes in hand as well with `latest` of images)

Depends on https://github.com/kiegroup/kogito-runtimes/pull/714