### PR TITLE
PLANNER-2216 Create release branches for Optawebs

### DIFF
--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -14,7 +14,7 @@ OPERATOR_PROMOTE = 'kogito-operator-promote'
 
 PIPELINE_REPOS=['kogito-pipelines']
 RUNTIMES_REPOS=['kogito-runtimes','kogito-apps','kogito-examples']
-OPTAPLANNER_REPOS =['optaplanner']
+OPTAPLANNER_REPOS =['optaplanner', 'optaweb-vehicle-routing', 'optaweb-employee-rostering']
 IMAGES_REPOS=['kogito-images']
 OPERATOR_REPOS=['kogito-cloud-operator']
 


### PR DESCRIPTION
A counterpart for https://github.com/kiegroup/optaplanner/pull/1045.

See https://issues.redhat.com/browse/PLANNER-2216.

Tests passed https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/rsynek/job/releasePipeline/job/kogito-release/28/