### PR TITLE
Create new release branch for optaplanner quickstarts based upon development

### DIFF
--- a/Jenkinsfile.create-release-branches
+++ b/Jenkinsfile.create-release-branches
@@ -1,5 +1,7 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
+CUSTOM_BASES=[:]
+
 pipeline {
     agent {
         label 'kie-rhel7 && !master'
@@ -11,6 +13,11 @@ pipeline {
         
         string(name: 'GIT_AUTHOR', defaultValue: 'kiegroup', description: 'Which Git author repository ?')
         string(name: 'GIT_AUTHOR_CREDS_ID', defaultValue: 'kie-ci', description: 'Git author credentials id')
+
+        string(name: 'NON_MASTER_BASES', defaultValue: '', description: 'Comma-separated list of custom bases in format repo:base')
+    }
+    environment {
+        DEFAULT_BASE_BRANCH = 'master'
     }
 
     stages {
@@ -23,6 +30,7 @@ pipeline {
 
                     currentBuild.displayName = "${getReleaseBranch()}"
                     currentBuild.description = "${getRepositories()}"
+                    CUSTOM_BASES = getCustomBasesMap()
                 }
             }
         }
@@ -36,7 +44,7 @@ pipeline {
                         echo "Checkout repo ${repo}"
                         dir(repo){
                             deleteDir()
-                            checkout(githubscm.resolveRepository(repo, getGitAuthor(), 'master', false))
+                            checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBaseBranch(repo), false))
                             sh 'git fetch origin'
                             String branchRemoteResult = sh(script: "git ls-remote origin ${getReleaseBranch()} | wc -l", returnStdout: true).trim()
                             if(Integer.parseInt(branchRemoteResult) > 0){
@@ -73,4 +81,17 @@ String getGitAuthorCredsId(){
 
 String[] getRepositories(){
     return params.REPOSITORIES.split(',')
+}
+
+String getBaseBranch(String repo) {
+    return (CUSTOM_BASES && CUSTOM_BASES.containsKey(repo))?CUSTOM_BASES.get(repo):env.DEFAULT_BASE_BRANCH;
+}
+
+def getCustomBasesMap() {
+    return params.NON_MASTER_BASES
+            .split(', ')
+            .collectEntries { entry ->
+                def pair = entry.split(':')
+                [(pair.first()): pair.last()]
+            }
 }

--- a/Jenkinsfile.create-release-branches
+++ b/Jenkinsfile.create-release-branches
@@ -6,7 +6,7 @@ pipeline {
     }
 
     parameters {
-        string(name: 'REPOSITORIES', defaultValue: '', description: 'Comma-separated list of repositories to update. Add branch name after semicolon to customize base')
+        string(name: 'REPOSITORIES', defaultValue: '', description: 'Comma-separated list of repository[:base branch] to update. The default base branch for every repository is the \'master\' branch.
         string(name: 'RELEASE_BRANCH', defaultValue: '', description: 'Release branch to create')
         
         string(name: 'GIT_AUTHOR', defaultValue: 'kiegroup', description: 'Which Git author repository ?')

--- a/Jenkinsfile.create-release-branches
+++ b/Jenkinsfile.create-release-branches
@@ -1,7 +1,5 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
-CUSTOM_BASES=[:]
-
 pipeline {
     agent {
         label 'kie-rhel7 && !master'

--- a/Jenkinsfile.create-release-branches
+++ b/Jenkinsfile.create-release-branches
@@ -8,13 +8,12 @@ pipeline {
     }
 
     parameters {
-        string(name: 'REPOSITORIES', defaultValue: '', description: 'Comma-separated list of repositories to update')
+        string(name: 'REPOSITORIES', defaultValue: '', description: 'Comma-separated list of repositories to update. Add branch name after semicolon to customize base')
         string(name: 'RELEASE_BRANCH', defaultValue: '', description: 'Release branch to create')
         
         string(name: 'GIT_AUTHOR', defaultValue: 'kiegroup', description: 'Which Git author repository ?')
         string(name: 'GIT_AUTHOR_CREDS_ID', defaultValue: 'kie-ci', description: 'Git author credentials id')
 
-        string(name: 'NON_MASTER_BASES', defaultValue: '', description: 'Comma-separated list of custom bases in format repo:base')
     }
     environment {
         DEFAULT_BASE_BRANCH = 'master'
@@ -30,7 +29,6 @@ pipeline {
 
                     currentBuild.displayName = "${getReleaseBranch()}"
                     currentBuild.description = "${getRepositories()}"
-                    CUSTOM_BASES = getCustomBasesMap()
                 }
             }
         }
@@ -44,7 +42,7 @@ pipeline {
                         echo "Checkout repo ${repo}"
                         dir(repo){
                             deleteDir()
-                            checkout(githubscm.resolveRepository(repo, getGitAuthor(), getBaseBranch(repo), false))
+                            checkout(githubscm.resolveRepository(getUrl(repo), getGitAuthor(), getBase(repo), false))
                             sh 'git fetch origin'
                             String branchRemoteResult = sh(script: "git ls-remote origin ${getReleaseBranch()} | wc -l", returnStdout: true).trim()
                             if(Integer.parseInt(branchRemoteResult) > 0){
@@ -83,15 +81,10 @@ String[] getRepositories(){
     return params.REPOSITORIES.split(',')
 }
 
-String getBaseBranch(String repo) {
-    return (CUSTOM_BASES && CUSTOM_BASES.containsKey(repo))?CUSTOM_BASES.get(repo):env.DEFAULT_BASE_BRANCH;
+String getUrl(String repo){
+    return repo.split(":")[0]
 }
 
-def getCustomBasesMap() {
-    return params.NON_MASTER_BASES
-            .split(', ')
-            .collectEntries { entry ->
-                def pair = entry.split(':')
-                [(pair.first()): pair.last()]
-            }
+String getBase(String repo){
+    return (repo.find(":"))?repo.split(":")[1]:env.DEFAULT_BASE_BRANCH
 }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -715,6 +715,3 @@ String removeVersionSuffixIfExist(String version){
     Integer[] versionSplit = util.parseVersion(version)
     return "${versionSplit[0]}.${versionSplit[1]}.${versionSplit[2]}"
 }
-String getCustomBases(){
-    return NON_MASTER_BASES.toMapString()[1..-2]
-}

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -15,9 +15,10 @@ OPERATOR_PROMOTE = 'kogito-operator-promote'
 
 PIPELINE_REPOS=['kogito-pipelines']
 RUNTIMES_REPOS=['kogito-runtimes','kogito-apps','kogito-examples']
-OPTAPLANNER_REPOS =['optaplanner', 'optaweb-vehicle-routing', 'optaweb-employee-rostering']
+OPTAPLANNER_REPOS =['optaplanner', 'optaweb-vehicle-routing', 'optaweb-employee-rostering', 'optaplanner-quickstarts']
 IMAGES_REPOS=['kogito-images']
 OPERATOR_REPOS=['kogito-cloud-operator']
+NON_MASTER_BASES=['optaplanner-quickstarts':'development']
 
 // Map of executed jobs
 // See https://javadoc.jenkins.io/plugin/workflow-support/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.html
@@ -60,24 +61,36 @@ pipeline {
     }
 
     environment {
-        KOGITO_CI_EMAIL_TO = credentials('KOGITO_CI_EMAIL_TO')
-
+        //TODO
+        //KOGITO_CI_EMAIL_TO = credentials('KOGITO_CI_EMAIL_TO')
+        KOGITO_CI_EMAIL_TO = "adupliak@redhat.com"
         // RELEASE_BRANCH => will be set in Initialization phase
 
         // We use quay as temporary registry for testing between the jobs instead of Openshift, due to https://issues.redhat.com/browse/KOGITO-2219
 
+        //TODO
         IMAGE_REGISTRY_CREDENTIALS = 'release_kogito'
         IMAGE_REGISTRY = 'quay.io'
+
+//        IMAGE_REGISTRY_CREDENTIALS = 'EMPTY_REGISTRY_CREDENTIALS'
+//        IMAGE_REGISTRY = 'EMPTY_REGISTRY'
+
         IMAGE_NAMESPACE = 'kiegroup'
         // Use nightly for now with a different tag but we should find another solution
         IMAGE_NAME_SUFFIX = 'nightly'
 
         // Credentials
-        GIT_AUTHOR='kiegroup'
-        GIT_AUTHOR_CREDS_ID = 'kie-ci' // username/password creds
-        BOT_AUTHOR='bsig-gh-bot'
-        BOT_AUTHOR_CREDS_ID='bsig-gh-bot' // username/password creds
-        GITHUB_TOKEN_CREDS_ID='kie-ci2-token' // secret text creds
+//        GIT_AUTHOR='kiegroup'
+//        GIT_AUTHOR_CREDS_ID = 'kie-ci' // username/password creds
+//        BOT_AUTHOR='bsig-gh-bot'
+//        BOT_AUTHOR_CREDS_ID='bsig-gh-bot' // username/password creds
+//        GITHUB_TOKEN_CREDS_ID='kie-ci2-token' // secret text creds
+
+        GIT_AUTHOR='dupliaka'
+        GIT_AUTHOR_CREDS_ID ='dupliaka' // username/password creds
+        BOT_AUTHOR='dupliaka-gh-bot'
+        BOT_AUTHOR_CREDS_ID='dupliaka-gh-bot' // username/password creds
+        GITHUB_TOKEN_CREDS_ID='dupliaka_gh_token' // secret text creds
 
         // Maven Nexus release parameters
         DEFAULT_STAGING_REPOSITORY = 'https://repository.jboss.org/nexus/content/groups/kogito-public/'
@@ -157,6 +170,7 @@ pipeline {
                     addStringParam(buildParams, 'RELEASE_BRANCH', getOptaPlannerReleaseBranch())
                     addStringParam(buildParams, 'GIT_AUTHOR', getGitAuthor())
                     addStringParam(buildParams, 'GIT_AUTHOR_CREDS_ID', getGitAuthorCredsId())
+                    addStringParam(buildParams, 'NON_MASTER_BASES', getCustomBases())
 
                     def repositories = []
                     if(isArtifactsDeploy()) {
@@ -171,7 +185,7 @@ pipeline {
                 }
             }
         }
-
+        /*
         stage('Build & Deploy Kogito Runtimes') {
             when {
                 expression { return !isCreateReleaseBranchesOnly() && isArtifactsDeploy() }
@@ -283,12 +297,12 @@ pipeline {
             steps {
                 script {
                     sendStageNotification()
-                    
+
                     def buildParams = getDefaultBuildParams(getKogitoOperatorVersion())
                     addSkipTestsParam(buildParams)
                     addReleaseDeployGitParams(buildParams)
                     addImageBuildParams(buildParams, '', getKogitoOperatorTempTag(), true, false)
-                    
+
                     // For BDD tests
                     // We use the quay image registry for temp images until https://issues.redhat.com/browse/KOGITO-2219 is solved
                     if(isImagesDeploy()){
@@ -392,7 +406,7 @@ pipeline {
             steps {
                 script {
                     sendStageNotification()
-                    
+
                     def buildParams = getDefaultBuildParams(getKogitoImagesVersion())
                     addStringParam(buildParams, 'DEPLOY_BUILD_URL', getJobUrl(IMAGES_DEPLOY))
                     addImageBuildParams(buildParams, 'PROMOTE', getKogitoImagesVersion(), true, true)
@@ -425,6 +439,7 @@ pipeline {
                 }
             }
         }
+         */
 
         // To be enabled later
         // stage("Deploy docs") {
@@ -713,4 +728,7 @@ String getKogitoOperatorTempTag(){
 String removeVersionSuffixIfExist(String version){
     Integer[] versionSplit = util.parseVersion(version)
     return "${versionSplit[0]}.${versionSplit[1]}.${versionSplit[2]}"
+}
+String getCustomBases(){
+    return NON_MASTER_BASES.toMapString()[1..-2]
 }

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -61,13 +61,13 @@ pipeline {
 
     environment {
         KOGITO_CI_EMAIL_TO = credentials('KOGITO_CI_EMAIL_TO')
+
         // RELEASE_BRANCH => will be set in Initialization phase
 
         // We use quay as temporary registry for testing between the jobs instead of Openshift, due to https://issues.redhat.com/browse/KOGITO-2219
 
-        IMAGE_REGISTRY_CREDENTIALS = 'EMPTY_REGISTRY_CREDENTIALS'
-        IMAGE_REGISTRY = 'EMPTY_REGISTRY'
-
+        IMAGE_REGISTRY_CREDENTIALS = 'release_kogito'
+        IMAGE_REGISTRY = 'quay.io'
         IMAGE_NAMESPACE = 'kiegroup'
         // Use nightly for now with a different tag but we should find another solution
         IMAGE_NAME_SUFFIX = 'nightly'

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -15,10 +15,9 @@ OPERATOR_PROMOTE = 'kogito-operator-promote'
 
 PIPELINE_REPOS=['kogito-pipelines']
 RUNTIMES_REPOS=['kogito-runtimes','kogito-apps','kogito-examples']
-OPTAPLANNER_REPOS =['optaplanner', 'optaweb-vehicle-routing', 'optaweb-employee-rostering', 'optaplanner-quickstarts']
+OPTAPLANNER_REPOS =['optaplanner', 'optaweb-vehicle-routing', 'optaweb-employee-rostering', 'optaplanner-quickstarts:development']
 IMAGES_REPOS=['kogito-images']
 OPERATOR_REPOS=['kogito-cloud-operator']
-NON_MASTER_BASES=['optaplanner-quickstarts':'development']
 
 // Map of executed jobs
 // See https://javadoc.jenkins.io/plugin/workflow-support/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.html
@@ -158,7 +157,6 @@ pipeline {
                     addStringParam(buildParams, 'RELEASE_BRANCH', getOptaPlannerReleaseBranch())
                     addStringParam(buildParams, 'GIT_AUTHOR', getGitAuthor())
                     addStringParam(buildParams, 'GIT_AUTHOR_CREDS_ID', getGitAuthorCredsId())
-                    addStringParam(buildParams, 'NON_MASTER_BASES', getCustomBases())
 
                     def repositories = []
                     if(isArtifactsDeploy()) {

--- a/Jenkinsfile.release
+++ b/Jenkinsfile.release
@@ -61,36 +61,24 @@ pipeline {
     }
 
     environment {
-        //TODO
-        //KOGITO_CI_EMAIL_TO = credentials('KOGITO_CI_EMAIL_TO')
-        KOGITO_CI_EMAIL_TO = "adupliak@redhat.com"
+        KOGITO_CI_EMAIL_TO = credentials('KOGITO_CI_EMAIL_TO')
         // RELEASE_BRANCH => will be set in Initialization phase
 
         // We use quay as temporary registry for testing between the jobs instead of Openshift, due to https://issues.redhat.com/browse/KOGITO-2219
 
-        //TODO
-        IMAGE_REGISTRY_CREDENTIALS = 'release_kogito'
-        IMAGE_REGISTRY = 'quay.io'
-
-//        IMAGE_REGISTRY_CREDENTIALS = 'EMPTY_REGISTRY_CREDENTIALS'
-//        IMAGE_REGISTRY = 'EMPTY_REGISTRY'
+        IMAGE_REGISTRY_CREDENTIALS = 'EMPTY_REGISTRY_CREDENTIALS'
+        IMAGE_REGISTRY = 'EMPTY_REGISTRY'
 
         IMAGE_NAMESPACE = 'kiegroup'
         // Use nightly for now with a different tag but we should find another solution
         IMAGE_NAME_SUFFIX = 'nightly'
 
         // Credentials
-//        GIT_AUTHOR='kiegroup'
-//        GIT_AUTHOR_CREDS_ID = 'kie-ci' // username/password creds
-//        BOT_AUTHOR='bsig-gh-bot'
-//        BOT_AUTHOR_CREDS_ID='bsig-gh-bot' // username/password creds
-//        GITHUB_TOKEN_CREDS_ID='kie-ci2-token' // secret text creds
-
-        GIT_AUTHOR='dupliaka'
-        GIT_AUTHOR_CREDS_ID ='dupliaka' // username/password creds
-        BOT_AUTHOR='dupliaka-gh-bot'
-        BOT_AUTHOR_CREDS_ID='dupliaka-gh-bot' // username/password creds
-        GITHUB_TOKEN_CREDS_ID='dupliaka_gh_token' // secret text creds
+        GIT_AUTHOR='kiegroup'
+        GIT_AUTHOR_CREDS_ID = 'kie-ci' // username/password creds
+        BOT_AUTHOR='bsig-gh-bot'
+        BOT_AUTHOR_CREDS_ID='bsig-gh-bot' // username/password creds
+        GITHUB_TOKEN_CREDS_ID='kie-ci2-token' // secret text creds
 
         // Maven Nexus release parameters
         DEFAULT_STAGING_REPOSITORY = 'https://repository.jboss.org/nexus/content/groups/kogito-public/'
@@ -185,7 +173,7 @@ pipeline {
                 }
             }
         }
-        /*
+
         stage('Build & Deploy Kogito Runtimes') {
             when {
                 expression { return !isCreateReleaseBranchesOnly() && isArtifactsDeploy() }
@@ -439,7 +427,7 @@ pipeline {
                 }
             }
         }
-         */
+
 
         // To be enabled later
         // stage("Deploy docs") {


### PR DESCRIPTION
OptaPlanner quick starts use development instead of master as a base for the next release branch. 
To be able to customize that I add one more parameter NON_MASTER_BASES.
User can specify for different repositories different bases in format repo1:branch1,repo2:branch2
By default if the parameter was not passed or it is empty - then master will be used

The test job could be found here https://rhba-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/custom/job/adupliak/job/quickstarts-release-pipeline/job/kogito-release/11/