### PR TITLE
[KOGITO-4121] - `buildah` is not supported in quarkus 1.11.0.Beta2

### DIFF
--- a/kogito-cloud-operator-jenkins-slave/image.yaml
+++ b/kogito-cloud-operator-jenkins-slave/image.yaml
@@ -1,5 +1,5 @@
 name: kogito-cloud-operator-jenkins-slave
-version: "0.12.0"
+version: "1.1.0"
 from: registry.redhat.io/openshift4/ose-jenkins-agent-base
 description: Image used by dynamic jenkins slave to build kogito-cloud-operator using podman
 modules:
@@ -16,7 +16,7 @@ modules:
       version: "19.3.1-java-11"
     - name: org.kie.kogito.maven 
       version: "3.6.3"
-    - name: org.kie.kogito.addSoftLink
+    - name: org.kie.kogito.addPodmanConfig
     - name: org.kie.kogito.jenkins-user
 packages:
   content_sets:
@@ -24,6 +24,8 @@ packages:
       - rhel-8-for-x86_64-baseos-rpms
       - rhel-8-for-x86_64-appstream-rpms
   install:
+    - podman
+    - podman-docker
     - gcc
     - zlib-devel
     - glibc-devel

--- a/kogito-cloud-operator-jenkins-slave/modules/addSoftLink/addSoftLink.sh
+++ b/kogito-cloud-operator-jenkins-slave/modules/addSoftLink/addSoftLink.sh
@@ -1,4 +1,0 @@
-#!/bin/sh
-set -e
-
-ln  -s  /usr/bin/buildah  /usr/bin/docker

--- a/kogito-cloud-operator-jenkins-slave/modules/addSoftLink/module.yaml
+++ b/kogito-cloud-operator-jenkins-slave/modules/addSoftLink/module.yaml
@@ -1,6 +1,0 @@
-name: org.kie.kogito.addSoftLink
-version: "latest"
-description: Adds soft link of docker pointing at buildah
-
-execute:
-  - script: addSoftLink.sh

--- a/kogito-cloud-operator-jenkins-slave/modules/addpodmanconfig/config/libpod.conf
+++ b/kogito-cloud-operator-jenkins-slave/modules/addpodmanconfig/config/libpod.conf
@@ -1,0 +1,1 @@
+cgroup_manager="cgroupfs"

--- a/kogito-cloud-operator-jenkins-slave/modules/addpodmanconfig/module.yaml
+++ b/kogito-cloud-operator-jenkins-slave/modules/addpodmanconfig/module.yaml
@@ -3,8 +3,8 @@ version: "latest"
 description: Update the libpod config
 
 artifacts:
-    - name: libpod.conf
-      path: config/libpod.conf
+  - name: libpod.conf
+    path: config/libpod.conf
 
 execute:
   - script: updateConfig.sh

--- a/kogito-cloud-operator-jenkins-slave/modules/addpodmanconfig/module.yaml
+++ b/kogito-cloud-operator-jenkins-slave/modules/addpodmanconfig/module.yaml
@@ -1,0 +1,10 @@
+name: org.kie.kogito.addPodmanConfig
+version: "latest"
+description: Update the libpod config
+
+artifacts:
+    - name: libpod.conf
+      path: config/libpod.conf
+
+execute:
+  - script: updateConfig.sh

--- a/kogito-cloud-operator-jenkins-slave/modules/addpodmanconfig/updateConfig.sh
+++ b/kogito-cloud-operator-jenkins-slave/modules/addpodmanconfig/updateConfig.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+mkdir -p /etc/containers/
+cp /tmp/artifacts/libpod.conf  /etc/containers/libpod.conf


### PR DESCRIPTION
Adding podman on the node to have option to use as container runtime engine
See: https://issues.redhat.com/browse/KOGITO-4121

Signed-off-by: Tarun Khandelwal <tarkhand@redhat.com>