### PR TITLE
Add permission to force push to stable branch in Optaplanner

### DIFF
--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -183,6 +183,7 @@ void setupReleaseJob(String jobFolder) {
 
             env('DEFAULT_STAGING_REPOSITORY', "${MAVEN_NEXUS_STAGING_PROFILE_URL}")
             env('ARTIFACTS_REPOSITORY', "${MAVEN_ARTIFACTS_REPOSITORY}")
+            env('GITHUB_TOKEN_CREDS_ID', "${GIT_AUTHOR_CREDENTIALS_ID}")
         }
     }
 }


### PR DESCRIPTION
On promote Optaplanner stage we are using
gh api repos/kiegroup/optaplanner-quickstarts/branches/stable/protection

Which is not awalible without admin rights. To set admin rights u need to set env var GITHUB_TOKEN.

It was pointed to GITHUB_TOKEN_CREDS_ID param which was not included by some reason to setup release job.

@Ginxo @radtriste 