### PR TITLE
KOGITO-4158 Added native PR job generation

### DIFF
--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -78,9 +78,9 @@ void setupKogitoRuntimesBDDPrJob(String jobFolder) {
     jobParams.git.repo_url = "https://github.com/${GIT_AUTHOR_NAME}/${jobParams.git.repository}/"
     jobParams.pr = [
         checkout_branch : '${ghprbTargetBranch}',
-        trigger_phrase : '.*[j|J]enkins,? run BDD tests.*',
+        trigger_phrase : '.*[j|J]enkins,? run BDD[ tests]?.*',
         trigger_phrase_only: true,
-        commitContext: 'BDD tests'
+        commitContext: 'BDD'
     ]
     jobParams.disable_concurrent = true
     KogitoJobTemplate.createPRJob(this, jobParams)

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/templates/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/templates/KogitoJobTemplate.groovy
@@ -90,7 +90,7 @@ class KogitoJobTemplate {
                 }
             }
 
-            if(jobParams.env) {
+            if (jobParams.env) {
                 environmentVariables {
                     jobParams.env.each {
                         env(it.key, it.value)
@@ -178,9 +178,22 @@ class KogitoJobTemplate {
         jobParams.pr = [
             trigger_phrase : '.*[j|J]enkins,? run LTS[ tests]?.*',
             trigger_phrase_only: true,
-            commitContext: "LTS (${quarkusLtsVersion}) tests"
+            commitContext: "LTS (${quarkusLtsVersion})"
         ]
         jobParams.env = [ QUARKUS_BRANCH: quarkusLtsVersion ]
+
+        return createPRJob(script, jobParams)
+    }
+
+    static def createNativePRJob(def script, Map jobParams = [:]) {
+        jobParams.job.description = "Run on demand native tests from ${jobParams.job.name} repository"
+        jobParams.job.name += '.native'
+        jobParams.pr = [
+            trigger_phrase : '.*[j|J]enkins,? run native[ tests]?.*',
+            trigger_phrase_only: true,
+            commitContext: 'Native'
+        ]
+        jobParams.env = [ NATIVE: true ]
 
         return createPRJob(script, jobParams)
     }


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4158

In order to launch directly native tests from PR.

Command will be `Jenkins run native[ tests]`

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/127
- https://github.com/kiegroup/kogito-runtimes/pull/1120