### PR TITLE
Seed job: Add disable triggers possibility

### DIFF
--- a/dsl/branch_config.yaml
+++ b/dsl/branch_config.yaml
@@ -18,3 +18,5 @@ dependent_repositories:
 #       name: another_gh_bot_author
 #       credentials_id: another_gh_bot_author_creds
   
+disable:
+  triggers: false

--- a/dsl/seed/Jenkinsfile.seed
+++ b/dsl/seed/Jenkinsfile.seed
@@ -291,7 +291,9 @@ def createBranchRepoConfig(String seedBranch, def branchConfig, def repoConfig) 
     }
     if(branchConfig.disable) {
         cfg.disable = cfg.disable ?: [:]
-        cfg.disable.putAll(branchConfig.disable)
+        branchConfig.disable.each { key, value -> 
+            cfg.disable[key] = cfg.disable[key] ? (cfg.disable[key] || value) : value
+        }
     }
     return cfg
 }

--- a/dsl/seed/Jenkinsfile.seed
+++ b/dsl/seed/Jenkinsfile.seed
@@ -70,6 +70,8 @@ pipeline {
                     iterateReposForEachBranch('Checkout repositories') { seedBranch, branchConfig ->
                         deleteDir()
 
+                        pipelinesRepoConfig = [:]
+
                         if (!getCustomBranchKey()) {
                             // Get pipelines and get dependent repositories from there
                             dir(PIPELINES_REPO) {
@@ -80,8 +82,10 @@ pipeline {
                                 try {
                                     Map branchDslConfig = readYaml file: "${DSL_BRANCH_CONFIG_FILE}"
                                     branchDslConfig['dependent_repositories'].each { repoConfig ->
-                                        branchConfig.put(repoConfig.name, createBranchRepoConfig(seedBranch, repoConfig))
+                                        branchConfig.put(repoConfig.name, createBranchRepoConfig(seedBranch, branchDslConfig, repoConfig))
                                     }
+
+                                    pipelinesRepoConfig = createBranchRepoConfig(seedBranch, branchDslConfig, [ name : PIPELINES_REPO])
                                     println "[INFO] Branch ${seedBranch} => Dependent repositories are ${branchConfig.keySet()}"
                                 } catch (err) {
                                     println "[ERROR] Cannot get repositories on branch ${seedBranch} => ${err}"
@@ -96,7 +100,7 @@ pipeline {
                                         name : getCustomAuthor() ?: getSeedAuthor()
                                     ]
                                 ]
-                                branchConfig.put(repoName, createBranchRepoConfig(seedBranch, repoConfig))
+                                branchConfig.put(repoName, createBranchRepoConfig(seedBranch, [:], repoConfig))
                             }
 
                             if(isDebug()) {
@@ -120,8 +124,8 @@ pipeline {
                         }
 
                         // After checkout add pipelines repo to the list of repo to test/generate
-                        if (!getCustomBranchKey()) {
-                            branchConfig.put(PIPELINES_REPO, createBranchRepoConfig(seedBranch, [ name : PIPELINES_REPO]))
+                        if (pipelinesRepoConfig) {
+                            branchConfig.put(PIPELINES_REPO, pipelinesRepoConfig)
                         }
                     }
                 }
@@ -271,7 +275,7 @@ String getSeedFolder(String seedBranch) {
     return "${getKeyBranchFolder(seedBranch)}/${SEED_FOLDER}"
 }
 
-def createBranchRepoConfig(String seedBranch, def repoConfig) {
+def createBranchRepoConfig(String seedBranch, def branchConfig, def repoConfig) {
     def cfg = getRepoBasicConfig(seedBranch, repoConfig.name)
     cfg.git.branch = repoConfig.branch ?: cfg.git.branch
     if (repoConfig.author) {
@@ -282,6 +286,10 @@ def createBranchRepoConfig(String seedBranch, def repoConfig) {
     if (repoConfig.bot_author) {
         cfg.git.bot_author.name = repoConfig.bot_author.name ?: cfg.git.bot_author.name
         cfg.git.bot_author.credentials_id = repoConfig.bot_author.credentials_id ?: cfg.git.bot_author.credentials_id
+    }
+    if(branchConfig.disable) {
+        cfg.disable = cfg.disable ?: [:]
+        cfg.disable.putAll(branchConfig.disable)
     }
     return cfg
 }

--- a/dsl/seed/Jenkinsfile.seed
+++ b/dsl/seed/Jenkinsfile.seed
@@ -5,6 +5,7 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 seedConfig = [:]
 seedEnvProperties = [:]
+customBranchConfig = [:] // Used for the custom configuration
 
 // Map<branch, Map<repo, config>>
 branchConfigs = [:]
@@ -44,6 +45,7 @@ pipeline {
                         sh "cat ${DSL_SEED_FOLDER}/config.yaml"
                     }
                     seedConfig = readYaml(file: "${DSL_SEED_FOLDER}/config.yaml")
+                    customBranchConfig = readYaml(file: "${DSL_BRANCH_CONFIG_FILE}")
 
                     branchConfigs = [:]
                     if (getCustomBranchKey()) {
@@ -100,7 +102,7 @@ pipeline {
                                         name : getCustomAuthor() ?: getSeedAuthor()
                                     ]
                                 ]
-                                branchConfig.put(repoName, createBranchRepoConfig(seedBranch, [:], repoConfig))
+                                branchConfig.put(repoName, createBranchRepoConfig(seedBranch, customBranchConfig, repoConfig))
                             }
 
                             if(isDebug()) {

--- a/dsl/seed/config.yaml
+++ b/dsl/seed/config.yaml
@@ -1,5 +1,3 @@
-jenkins_email_creds_id: KOGITO_CI_EMAIL_TO
-quarkus_lts_version: '1.11'
 git:
   branches:
   - master
@@ -33,3 +31,9 @@ cloud:
     registry: quay.io
     namespace: kiegroup
     latest_git_branch: master
+jenkins:
+  email_creds_id: KOGITO_CI_EMAIL_TO
+quarkus:
+  lts_version: '1.11'
+disable:
+  triggers: false

--- a/dsl/seed/config.yaml.explanations
+++ b/dsl/seed/config.yaml.explanations
@@ -1,7 +1,5 @@
 # The configuration present here will be available as uppercase env vars for job generation
 
-##### MISC
-jenkins_email_creds_id: KOGITO_CI_EMAIL_TO
 ##### GIT
 git:
   # Each branch will be accessible as `GIT_BRANCH` env var
@@ -17,6 +15,7 @@ git:
   # Each main branch will be accessible as `GIT_MAIN_BRANCH` env var
   main_branch:
     default: master
+
 ##### MAVEN
 maven:
   settings_file_id: 2bd418aa-56fa-4403-9232-8c77a50fc528
@@ -32,6 +31,7 @@ maven:
     repository: 
       url: 'https://bxms-qe.rhev-ci-vms.eng.rdu2.redhat.com:8443/nexus/content/repositories/kogito-runtimes-pr-full-testing/'
       creds_id: 'unpacks-zip-on-qa-nexus'
+
 ##### CLOUD
 cloud:
   image:
@@ -40,3 +40,11 @@ cloud:
     registry: quay.io
     namespace: kiegroup
     latest_git_branch: master
+
+##### MISC
+jenkins:
+  email_creds_id: KOGITO_CI_EMAIL_TO
+quarkus:
+  lts_version: '1.11'
+disable:
+  triggers: false

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
@@ -22,4 +22,12 @@ class Utils {
         return script.getBinding()[key]
     }
 
+
+    static String getQuarkusLTSVersion() {
+        return getBindingValue(script, 'QUARKUS_LTS_VERSION')
+    }
+
+    static boolean areTriggersDisabled() {
+        return getBindingValue(script, 'DISABLE_TRIGGERS').toBoolean()
+    }
 }

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
@@ -23,11 +23,11 @@ class Utils {
     }
 
 
-    static String getQuarkusLTSVersion() {
+    static String getQuarkusLTSVersion(def script) {
         return getBindingValue(script, 'QUARKUS_LTS_VERSION')
     }
 
-    static boolean areTriggersDisabled() {
+    static boolean areTriggersDisabled(def script) {
         return getBindingValue(script, 'DISABLE_TRIGGERS').toBoolean()
     }
 }

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/templates/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/templates/KogitoJobTemplate.groovy
@@ -19,7 +19,7 @@ class KogitoJobTemplate {
                 numToKeep(10)
             }
 
-            if (!Utils.areTriggersDisabled() && jobParams.triggers && jobParams.triggers.cron) {
+            if (!Utils.areTriggersDisabled(script) && jobParams.triggers && jobParams.triggers.cron) {
                 triggers {
                     cron (jobParams.triggers.cron)
                 }
@@ -171,7 +171,7 @@ class KogitoJobTemplate {
     }
 
     static def createQuarkusLTSPRJob(def script, Map jobParams = [:]) {
-        def quarkusLtsVersion = Utils.getQuarkusLTSVersion()
+        def quarkusLtsVersion = Utils.getQuarkusLTSVersion(script)
 
         jobParams.job.description = "Run on demand tests from ${jobParams.job.name} repository against quarkus LTS"
         jobParams.job.name += '.quarkus-lts'

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/templates/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/templates/KogitoJobTemplate.groovy
@@ -19,7 +19,7 @@ class KogitoJobTemplate {
                 numToKeep(10)
             }
 
-            if (jobParams.triggers && jobParams.triggers.cron) {
+            if (!Utils.areTriggersDisabled() && jobParams.triggers && jobParams.triggers.cron) {
                 triggers {
                     cron (jobParams.triggers.cron)
                 }
@@ -171,7 +171,7 @@ class KogitoJobTemplate {
     }
 
     static def createQuarkusLTSPRJob(def script, Map jobParams = [:]) {
-        def quarkusLtsVersion = Utils.getBindingValue(script, 'QUARKUS_LTS_VERSION')
+        def quarkusLtsVersion = Utils.getQuarkusLTSVersion()
 
         jobParams.job.description = "Run on demand tests from ${jobParams.job.name} repository against quarkus LTS"
         jobParams.job.name += '.quarkus-lts'


### PR DESCRIPTION
Can be useful for example when a release branch should be silent until we reactivate it (if we need to do it).

Or for testing purpose to disable any trigger when generating the jobs (we usually don't need them)