### PR TITLE
Set nightly to execute @midnight

### DIFF
--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -116,7 +116,7 @@ void setupCreateIssueToolsJob(String jobFolder) {
 
 void setupNightlyJob(String jobFolder) {
     def jobParams = getJobParams('kogito-nightly', jobFolder, 'Jenkinsfile.nightly', 'Kogito Nightly')
-    jobParams.triggers = [cron : '@daily']
+    jobParams.triggers = [cron : '@midnight']
     KogitoJobTemplate.createPipelineJob(this, jobParams).with {
         parameters {
             booleanParam('SKIP_TESTS', false, 'Skip all tests')


### PR DESCRIPTION
Because daily depends on the latest execution and so could happen when everyone is working. which is causing problems for Cloud if anything breaks ...