### PR TITLE
Remove rhpam kogito operator from community pipelines

### DIFF
--- a/Jenkinsfile.release.prepare
+++ b/Jenkinsfile.release.prepare
@@ -11,7 +11,7 @@ PIPELINE_REPOS = ["${PIPELINE_REPO}"]
 RUNTIMES_REPOS = ['kogito-runtimes', 'kogito-apps', 'kogito-examples']
 OPTAPLANNER_REPOS = ["${OPTAPLANNER_REPO}", 'optaweb-vehicle-routing', 'optaweb-employee-rostering', 'optaplanner-quickstarts:development']
 IMAGES_REPOS = ['kogito-images']
-OPERATOR_REPOS = ['kogito-operator', 'rhpam-kogito-operator']
+OPERATOR_REPOS = ['kogito-operator']
 
 JOBS = [:]
 


### PR DESCRIPTION
No community branch will be created on `rhpam-kogito-operator` anymore.
Branches will be needed to be created manually