### PR TITLE
Prepare release for product repos option

### DIFF
--- a/.jenkins/dsl/jobs.groovy
+++ b/.jenkins/dsl/jobs.groovy
@@ -211,6 +211,8 @@ void setupPrepareReleaseJob(String jobFolder) {
             stringParam('KOGITO_VERSION', '', 'Project version to release as Major.minor.micro')
             stringParam('OPTAPLANNER_VERSION', '', 'Project version of OptaPlanner and its examples to release as Major.minor.micro')
             stringParam('OPTAPLANNER_RELEASE_BRANCH', '', 'Use to override the release branch name deduced from the OPTAPLANNER_VERSION')
+
+            booleanParam('BRANCH_PRODUCT_REPOSITORIES', false, 'Set to true to create branch also on Product repositories')
         }
 
         environmentVariables {

--- a/Jenkinsfile.release.prepare
+++ b/Jenkinsfile.release.prepare
@@ -13,6 +13,8 @@ OPTAPLANNER_REPOS = ["${OPTAPLANNER_REPO}", 'optaweb-vehicle-routing', 'optaweb-
 IMAGES_REPOS = ['kogito-images']
 OPERATOR_REPOS = ['kogito-operator']
 
+KOGITO_PRODUCT_REPOS = ['rhpam-kogito-operator']
+
 JOBS = [:]
 
 pipeline {
@@ -63,6 +65,10 @@ pipeline {
                     repositories += IMAGES_REPOS
                     repositories += OPERATOR_REPOS
                     repositories += PIPELINE_REPOS // Create branch to activate nightlies if needed
+
+                    if(params.BRANCH_PRODUCT_REPOSITORIES) {
+                        repositories += KOGITO_PRODUCT_REPOS
+                    }
 
                     echo "Call ${CREATE_RELEASE_BRANCHES} job with repositories ${repositories}"
                     addStringParam(buildParams, 'REPOSITORIES', repositories.join(','))

--- a/Jenkinsfile.release.prepare
+++ b/Jenkinsfile.release.prepare
@@ -111,6 +111,10 @@ pipeline {
                         repositories.addAll(collectRepos(OPERATOR_REPOS, getKogitoReleaseBranch()))
                         repositories.addAll(collectRepos([OPTAPLANNER_REPO], getOptaPlannerReleaseBranch()))
 
+                        if(params.BRANCH_PRODUCT_REPOSITORIES) {
+                            repositories.addAll(collectRepos(KOGITO_PRODUCT_REPOS, getKogitoReleaseBranch()))
+                        }
+
                         def branchConfig = [ dependent_repositories : repositories]
 
                         echo "Write dsl branch_config => ${branchConfig}"


### PR DESCRIPTION
Add an option to `Prepare release branch` job to also branch product repositories for Kogito on-demand.
If checked, then product repositories (`rhpam-kogito-operator`) will be automatically branched with the same branch as for community