### PR TITLE
Fix GHA config to prevent tests failure hiding

### DIFF
--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -3,7 +3,7 @@ version: "2.0"
 dependencies: ./project-dependencies.yaml
 
 pre: |
-  export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -Dmaven.test.failure.ignore=true -fae -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120"
+  export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -nsu -fae -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120"
   echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
 
 default:
@@ -25,7 +25,7 @@ build:
 
   - project: kiegroup/optaplanner
     build-command: 
-      current: mvn -f optaplanner/pom.xml -nsu clean install -Dfull ${{ env.BUILD_MVN_OPTS }}
+      current: mvn -f optaplanner/pom.xml clean install -Dfull ${{ env.BUILD_MVN_OPTS }}
     clone:
       - optaplanner
 


### PR DESCRIPTION
When a test fails during the initialisation, the error is not producing a failsafe/surefire `TEST-*.xml` file. These files are used to parse and produce test report.
This PR make the build fail even if it is not solving the issue with test report

For example a similar error
```
[ERROR] Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 0.008 s <<< FAILURE! - in org.kie.kogito.explainability.rest.KeycloakExplainabilityServiceIT
[ERROR] org.kie.kogito.explainability.rest.KeycloakExplainabilityServiceIT.shouldReturnUnauthorized  Time elapsed: 0 s  <<< ERROR!
org.junit.jupiter.api.extension.TestInstantiationException: Failed to create test instance
Caused by: java.lang.reflect.InvocationTargetException
Caused by: java.lang.IllegalStateException: Mapped port can only be obtained after the container is started
```
is not producing test report