### PR TITLE
KOGITO-4485 Update nightly branch in examples

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -157,6 +157,7 @@ pipeline {
                     echo "Call ${EXAMPLES_DEPLOY} job"
                     def buildParams = getDefaultBuildParams()
                     addSkipTestsParam(buildParams)
+                    addBooleanParam(buildParams, 'UPDATE_NIGHTLY_BRANCH', true)
 
                     // images and operator deploy testing will use older working artifacts if that one fails
                     buildJob(EXAMPLES_DEPLOY, buildParams, false)


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-4485

The nightly branch will be used by Cloud team to have more or less stable environment to test against and avoid any daily breaking change in runtimes/examples.

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/171
- https://github.com/kiegroup/kogito-examples/pull/702