### PR TITLE
KOGITO-5192 Fix some validation issues in update scripts

### DIFF
--- a/tools/update-kie7-versions.sh
+++ b/tools/update-kie7-versions.sh
@@ -7,6 +7,7 @@ BRANCH=master
 DEFAULT_BRANCH=master
 DRY_RUN=false
 FORK=
+KIE_VERSION=
 
 usage() {
     echo 'Usage: update-kie7-versions.sh -p $PROJECT -s $KIE_VERSION -b $BASE_BRANCH -f $FORK [-n]'
@@ -108,8 +109,10 @@ echo BRANCH.......$BRANCH
 echo PR_BRANCH....$PR_BRANCH
 echo VERSION......$KIE_VERSION
 echo
+if [ "$DRY_RUN" = "true" ]; then
 echo DRY_RUN! No changes will be pushed!
 echo
+fi
 
 
 git clone https://github.com/$ORIGIN
@@ -130,7 +133,7 @@ versions:set-property \
 # commit all
 git commit -am "[$BRANCH] Bump KIE $KIE_VERSION"
  
-if [ "$DRY_RUN" = "" ]; then
+if [ "$DRY_RUN" = "false" ]; then
     # push the branch to a remote
     git push -u $PR_FORK $PR_BRANCH
     

--- a/tools/update-quarkus-platform.sh
+++ b/tools/update-quarkus-platform.sh
@@ -111,8 +111,10 @@ echo KOGITO_VERSION...........$KOGITO_VERSION
 echo OPTAPLANNER_VERSION......$OPTAPLANNER_VERSION
 echo COMMAND..................$COMMAND
 echo
+if [ "$DRY_RUN" = "true" ]; then
 echo DRY_RUN! No changes will be pushed!
 echo
+fi
 
 
 stage() {
@@ -146,7 +148,7 @@ stage() {
     # commit all
     git commit -am "Kogito $KOGITO_VERSION + OptaPlanner $OPTAPLANNER_VERSION"
 
-    if [ "$DRY_RUN" = "" ]; then
+    if [ "$DRY_RUN" = "false" ]; then
         # push the branch to a remote
         git push -u $PR_FORK $PR_BRANCH
         # Open a PR to kogito-runtimes using the commit as a title
@@ -174,7 +176,7 @@ finalize() {
     # overwrite old commit (no need to squash)
     git commit --amend --no-edit pom.xml
     
-    if [ "$DRY_RUN" = "" ]; then
+    if [ "$DRY_RUN" = "false" ]; then
         # push forced (we are overwriting the old commit)
         git push --force-with-lease
     fi

--- a/tools/update-quarkus-versions.sh
+++ b/tools/update-quarkus-versions.sh
@@ -109,8 +109,10 @@ echo BRANCH.......$BRANCH
 echo PR_BRANCH....$PR_BRANCH
 echo VERSION......$QUARKUS_VERSION
 echo
+if [ "$DRY_RUN" = "true" ]; then
 echo DRY_RUN! No changes will be pushed!
 echo
+fi
 
 # print all commands
 set -x
@@ -146,7 +148,7 @@ versions:set-property \
 # commit all
 git commit -am "Bump Quarkus $QUARKUS_VERSION"
 
-if [ "$DRY_RUN" = "" ]; then
+if [ "$DRY_RUN" = "false" ]; then
    # push the branch to a remote
    git push -u https://github.com/$PR_FORK $PR_BRANCH
    


### PR DESCRIPTION
- "dry run" is always true regardless the flags
- the "dry run" line is always displayed
- kie version is not set (causes failure when validating input)