### PR TITLE
build-chain version 2.1

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -1,4 +1,4 @@
-version: "2.0"
+version: "2.1"
 dependencies:
   - project: kiegroup/kogito-runtimes
   

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -1,4 +1,4 @@
-version: "2.0"
+version: "2.1"
 
 dependencies: ./project-dependencies.yaml
 


### PR DESCRIPTION
@radtriste is there any other flow using these definition and project dependencies files?
They all should be updated to `kiegroup/github-action-build-chain@v2.6`

### Referenced pull requests

- https://github.com/kiegroup/kogito-pipelines/pull/182
- https://github.com/kiegroup/kogito-examples/pull/723
- https://github.com/kiegroup/kogito-apps/pull/876
- https://github.com/kiegroup/kogito-runtimes/pull/1358
- https://github.com/kiegroup/optaplanner/pull/1365