### PR TITLE
build-chain optaplanner mapping

### DIFF
--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -5,7 +5,16 @@ dependencies:
   - project: kiegroup/optaplanner
     dependencies:
       - project: kiegroup/kogito-runtimes
-  
+    mapping:
+      dependencies:
+        default:
+          - source: (\d*)\.(.*)\.(.*)
+            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1-7}.${n2}.${n3}`)"
+      dependant:
+        default:
+          - source: (\d*)\.(.*)\.(.*)
+            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1+7}.${n2}.${n3}`)" 
+
   - project: kiegroup/kogito-apps
     dependencies:
       - project: kiegroup/kogito-runtimes


### PR DESCRIPTION
the master to master will be automatically considered since `source: (\\d*)\\.(.*)\\.(.*)` won't match with `master` so straight mapping will be taken into account.