### PR TITLE
Updated Nightly timeout

### DIFF
--- a/Jenkinsfile.nightly
+++ b/Jenkinsfile.nightly
@@ -37,7 +37,7 @@ pipeline {
     }
 
     options {
-        timeout(time: 720, unit: 'MINUTES')
+        timeout(time: 1380, unit: 'MINUTES')
     }
 
     // parameters {


### PR DESCRIPTION
Will solve some current timeout issues due to node creation.
Set to 23 hours (we stop anyway 1 hour before the next start)