### PR TITLE
kie7 bump is not pushing to the correct URL

### DIFF
--- a/tools/update-kie7-versions.sh
+++ b/tools/update-kie7-versions.sh
@@ -113,7 +113,7 @@ git commit -am "[$BRANCH] Bump KIE $KIE_VERSION"
  
 if [ "$DRY_RUN" = "false" ]; then
     # push the branch to a remote
-    git push -u $PR_FORK $PR_BRANCH
+    git push -u https://github.com/$PR_FORK $PR_BRANCH
     
     # Open a PR to kogito-runtimes using the commit as a title
     # e.g. see https://github.com/kiegroup/kogito-runtimes/pull/1200


### PR DESCRIPTION
was pushing to `$PR_FORK` instead of `https://github.com/$PR_FORK `