### PR TITLE
KOGITO-5486 Branch config to enable LTS checks

### DIFF
--- a/dsl/seed/config/branch.yaml
+++ b/dsl/seed/config/branch.yaml
@@ -1,5 +1,7 @@
+# Disabled until Quarkus 2.2 is out
+# Follow-up issue: https://issues.redhat.com/browse/KOGITO-5487
 lts:
-  enabled: true
+  enabled: false
   quarkus_version: '1.11'
 
 disable:

--- a/dsl/seed/config/branch.yaml
+++ b/dsl/seed/config/branch.yaml
@@ -1,3 +1,11 @@
+lts:
+  enabled: true
+  quarkus_version: '1.11'
+
+disable:
+  triggers: false
+  branch: false
+
 repositories:
   - name: kogito-pipelines
   - name: kogito-runtimes
@@ -54,8 +62,3 @@ cloud:
     latest_git_branch: master
 jenkins:
   email_creds_id: KOGITO_CI_EMAIL_TO
-quarkus:
-  lts_version: '1.11'
-disable:
-  triggers: false
-  branch: false

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
@@ -36,13 +36,17 @@ class Utils {
     }
 
     static String getQuarkusLTSVersion(def script) {
-        return getBindingValue(script, 'QUARKUS_LTS_VERSION')
+        return getBindingValue(script, 'LTS_QUARKUS_VERSION')
     }
 
     static boolean isMainBranch(def script) {
         boolean result = getGitBranch(script) == getGitMainBranch(script)
         script.println("Branch=${getGitBranch(script)}. Main Branch=${getGitMainBranch(script)}. Is main branch ? => ${result}")
         return result
+    }
+
+    static boolean isLTSBranch(def script) {
+        return getBindingValue(script, 'LTS_ENABLED').toBoolean()
     }
 
     static String getRepoName(def script) {


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5486

This will allow centralized information about LTS and possibility to extend its usage (thinking about Mandrel here)

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/209
- https://github.com/kiegroup/kogito-runtimes/pull/1433