### PR TITLE
[1.9.x] Deactivate triggers

### DIFF
--- a/dsl/seed/config/branch.yaml
+++ b/dsl/seed/config/branch.yaml
@@ -62,5 +62,5 @@ jenkins:
 quarkus:
   lts_version: '1.11'
 disable:
-  triggers: false
+  triggers: true
   branch: false


### PR DESCRIPTION
1.9.x branch should no more be used.
Disabling triggers for now to avoid Jenkins overloading.
Removal of jobs will be done later