### PR TITLE
[KOGITO-5268] - Update Quarkus script tool with Kogito Dependencies BOM

### DIFF
--- a/tools/update-quarkus-versions.sh
+++ b/tools/update-quarkus-versions.sh
@@ -149,6 +149,7 @@ do
   mvn -pl :${i} \
      versions:set-property \
      -Dproperty=version.io.quarkus \
+     -Dproperty=version.io.quarkus.quarkus-test-maven \
      -DnewVersion=$QUARKUS_VERSION \
      -DgenerateBackupPoms=false
  

--- a/tools/update-quarkus-versions.sh
+++ b/tools/update-quarkus-versions.sh
@@ -76,13 +76,18 @@ echo "PROJECT = $PROJECT"
 
 # kogito-runtimes or optaplanner
 REPO=kogito-runtimes
+declare -a MODULES
 
 case $PROJECT in
     kogito)
         REPO=kogito-runtimes
+        MODULES[0]=kogito-dependencies-bom
+        MODULES[1]=kogito-build-parent
+        MODULES[2]=kogito-quarkus-bom
         ;;
     optaplanner)
         REPO=optaplanner
+        MODULES[0]=optaplanner-build-parent
         ;;
     *)
         >&2 echo ERROR: Unknown project: $PROJECT.
@@ -130,27 +135,30 @@ cd $REPO
 # create branch named like version
 git checkout -b $PR_BRANCH
  
-# align third-party dependencies with Quarkus
-mvn versions:compare-dependencies \
--pl :${PROJECT}-build-parent \
--DremotePom=io.quarkus:quarkus-bom:$QUARKUS_VERSION \
--DupdatePropertyVersions=true \
--DupdateDependencies=true \
--DgenerateBackupPoms=false
+for i in "${MODULES[@]}"
+do
+  # align third-party dependencies with Quarkus
+  mvn versions:compare-dependencies \
+  -pl :${i} \
+  -DremotePom=io.quarkus:quarkus-bom:$QUARKUS_VERSION \
+  -DupdatePropertyVersions=true \
+  -DupdateDependencies=true \
+  -DgenerateBackupPoms=false
  
-# update Quarkus version
-mvn -pl :${PROJECT}-build-parent \
-   versions:set-property \
-   -Dproperty=version.io.quarkus \
-   -DnewVersion=$QUARKUS_VERSION \
+  # update Quarkus version
+  mvn -pl :${i} \
+     versions:set-property \
+     -Dproperty=version.io.quarkus \
+     -DnewVersion=$QUARKUS_VERSION \
+     -DgenerateBackupPoms=false
+ 
+  # pin Maven version
+  mvn -pl :${i} \
+  versions:set-property \
+   -Dproperty=version.maven \
+   -DnewVersion=$MAVEN_VERSION \
    -DgenerateBackupPoms=false
- 
-# pin Maven version
-mvn -pl :${PROJECT}-build-parent \
-versions:set-property \
--Dproperty=version.maven \
--DnewVersion=$MAVEN_VERSION \
--DgenerateBackupPoms=false
+done
  
 # commit all
 git commit -am "Bump Quarkus $QUARKUS_VERSION"


### PR DESCRIPTION
Signed-off-by: Ricardo Zanini <zanini@redhat.com>

See https://issues.redhat.com/browse/KOGITO-5268

Blocked by:
- https://github.com/kiegroup/kogito-runtimes/pull/1515

In this PR we introduce a small change in our tooling script to update all descriptors related to Quarkus. Here's the result of my "downgrade" performed locally:

```log
[INFO] ---------------< org.kie.kogito:kogito-dependencies-bom >---------------
[INFO] Building Kogito :: Dependencies :: BOM 2.0.0-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[WARNING] The POM for org.eclipse.m2e:lifecycle-mapping:jar:1.0.0 is missing, no dependency information available
[WARNING] Failed to retrieve plugin descriptor for org.eclipse.m2e:lifecycle-mapping:1.0.0: Plugin org.eclipse.m2e:lifecycle-mapping:1.0.0 or one of its dependencies could not be resolved: Failure to find org.eclipse.m2e:lifecycle-mapping:jar:1.0.0 in https://repo.maven.apache.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced
[INFO] 
[INFO] --- versions-maven-plugin:2.8.1:compare-dependencies (default-cli) @ kogito-dependencies-bom ---
[INFO] Not updating ${version.javax.inject}: no info for javax.inject:javax.inject:jar
[INFO] Not updating ${version.com.github.java-json-tools}: no info for com.github.java-json-tools:json-schema-validator:jar
[INFO] Not updating ${version.org.slf4j}: no info for org.slf4j:slf4j-nop:jar
[INFO] Not updating ${version.plexus.classworld}: no info for org.codehaus.plexus:plexus-classworlds:jar
[INFO] Not updating ${version.plexus}: no info for org.codehaus.plexus:plexus-container-default:jar
[INFO] Not updating ${version.org.openapitools.jackson.databind.nullable}: no info for org.openapitools:jackson-databind-nullable:jar
[INFO] Not updating ${version.javax.validation}: no info for javax.validation:validation-api:jar
[INFO] Updated ${version.com.fasterxml.jackson} from 2.12.4 to 2.12.3
[INFO] Updated ${version.io.smallrye-open-api-core} from 2.1.7 to 2.1.6
[INFO] Not updating ${version.io.swagger.parser.v3}: no info for io.swagger.parser.v3:swagger-parser:jar
[INFO] Not updating ${version.io.serverlessworkflow}: no info for io.serverlessworkflow:serverlessworkflow-api:jar
[INFO] Updated ${version.org.jboss.resteasy} from 4.7.0.Final to 4.6.1.Final
[INFO] Updated ${version.org.mockito} from 3.11.2 to 3.10.0
[INFO] Not updating ${version.com.thoughtworks.xstream}: no info for com.thoughtworks.xstream:xstream:jar
[INFO] Not updating ${version.com.google.protobuf}: no info for com.google.protobuf:protobuf-java-util:jar
[INFO] Not updating ${version.org.reflections}: no info for org.reflections:reflections:jar
[INFO] Not updating ${version.org.hamcrest}: no info for org.hamcrest:hamcrest-core:jar
[INFO] Updated ${version.org.assertj} from 3.20.2 to 3.19.0
[INFO] Not updating ${version.org.json-unit-assertj}: no info for net.javacrumbs.json-unit:json-unit-assertj:jar
[INFO] Not updating ${version.io.cloudevents}: no info for io.cloudevents:cloudevents-api:jar
[INFO] Updated ${version.io.micrometer} from 1.7.2 to 1.7.0
[INFO] Not updating ${version.com.github.haifengl.smile}: no info for com.github.haifengl:smile-core:jar
[INFO] Not updating ${version.org.mvel}: no info for org.mvel:mvel2:jar
[INFO] Not updating ${version.javax.annotation}: no info for javax.annotation:javax.annotation-api:jar
[INFO] Not updating ${version.com.github.javaparser}: no info for com.github.javaparser:javaparser-core:jar
[INFO] Not updating ${version.com.jayway.jsonpath}: no info for com.jayway.jsonpath:json-path:jar
[INFO] Updated ${version.io.vertx} from 4.1.2 to 4.1.0
[INFO] Updated ${version.io.fabric8.kubernetes-client} from 5.6.0 to 5.4.1
[INFO] Not updating ${version.ch.qos.logback}: no info for ch.qos.logback:logback-classic:jar
[INFO] Not updating ${version.com.sun.activation}: no info for com.sun.activation:javax.activation:jar
[INFO] Updated ${version.org.mongo} from 4.3.0 to 4.2.3
[INFO] Not updating ${version.org.infinispan}: no info for org.infinispan:infinispan-commons-jdk11:jar
[INFO] Not updating ${version.com.github.victools}: no info for com.github.victools:jsonschema-generator:jar
[INFO] Updated ${version.maven} from 3.6.2 to 3.8.1
[INFO] Not updating ${version.org.openapitools}: no info for org.openapitools:openapi-generator:jar
[INFO] Not updating ${version.org.apache.xmlgraphics.batik}: no info for org.apache.xmlgraphics:batik-anim:jar
[INFO] Updated ${version.io.smallrye.reactive.mutiny-vertx-web-client} from 2.12.0 to 2.7.0
[INFO] Not updating ${version.com.sun.xml.bind}: no info for com.sun.xml.bind:jaxb-core:jar
[INFO] Not updating ${version.com.github.tomakehurst.wiremock}: no info for com.github.tomakehurst:wiremock-jre8:jar

[INFO] -----------------< org.kie.kogito:kogito-quarkus-bom >------------------
[INFO] Building Kogito :: Quarkus :: BOM 2.0.0-SNAPSHOT
[INFO] --------------------------------[ pom ]---------------------------------
[INFO] 
[INFO] --- versions-maven-plugin:2.5:compare-dependencies (default-cli) @ kogito-quarkus-bom ---
[INFO] Updated ${version.io.smallrye.reactive} from 3.7.1 to 3.5.0
```
