### PR TITLE
KOGITO-5730 Restructure DSL folders

### DIFF
--- a/dsl/seed/config/branch.yaml
+++ b/dsl/seed/config/branch.yaml
@@ -28,6 +28,7 @@ repositories:
 # repositories:
 #   - name: NAME
 #     branch: branch_name
+#     disabled: false
 #     author:
 #       name: another_gh_author
 #       credentials_id: another_gh_author_creds

--- a/dsl/seed/config/main.yaml
+++ b/dsl/seed/config/main.yaml
@@ -1,7 +1,6 @@
 git:
   branches:
   - main
-  - 1.10.x
   - 1.11.x
   main_branch:
     default: main

--- a/dsl/seed/jobs/Jenkinsfile.seed.branch
+++ b/dsl/seed/jobs/Jenkinsfile.seed.branch
@@ -61,7 +61,7 @@ pipeline {
             stages {
                 stage('Generate jobs') {
                     agent {
-                        label 'kie-rhel7 && kie-mem4g'
+                        label 'kie-rhel7 && kie-mem8g'
                     }
                     tools {
                         jdk 'kie-jdk1.8'
@@ -87,8 +87,8 @@ pipeline {
                                                         sandbox: false,
                                                         ignoreExisting: false,
                                                         ignoreMissingFiles: false,
-                                                        removedJobAction: 'IGNORE',
-                                                        removedViewAction: 'IGNORE',
+                                                        removedJobAction: 'DISABLE',
+                                                        removedViewAction: 'DELETE',
                                                         //removedConfigFilesAction: 'IGNORE',
                                                         lookupStrategy: 'SEED_JOB',
                                                         additionalClasspath: 'src/main/groovy',
@@ -139,7 +139,7 @@ pipeline {
 }
 
 String getRepoBranchSeedJobName(String repository) {
-    return "z-seed-${GENERATION_BRANCH}-${repository}-job"
+    return "z-seed-${repository}-job"
 }
 
 boolean getMainBranch(String repository) {

--- a/dsl/seed/jobs/Jenkinsfile.seed.main
+++ b/dsl/seed/jobs/Jenkinsfile.seed.main
@@ -56,7 +56,7 @@ pipeline {
             stages {
                 stage('Generate jobs') {
                     agent {
-                        label 'kie-rhel7 && kie-mem4g'
+                        label 'kie-rhel7 && kie-mem8g'
                     }
                     tools {
                         jdk 'kie-jdk1.8'
@@ -117,8 +117,8 @@ pipeline {
                                                 sandbox: false,
                                                 ignoreExisting: false,
                                                 ignoreMissingFiles: false,
-                                                removedJobAction: 'IGNORE',
-                                                removedViewAction: 'IGNORE',
+                                                removedJobAction: 'DELETE',
+                                                removedViewAction: 'DELETE',
                                                 //removedConfigFilesAction: 'IGNORE',
                                                 lookupStrategy: 'SEED_JOB',
                                                 additionalParameters : [
@@ -156,7 +156,7 @@ pipeline {
 }
 
 String getBranchSeedJobName(String branch) {
-    return "z-seed-${branch}-job"
+    return "z-seed-job"
 }
 
 void launchBranchSeedJob(String branch) {
@@ -170,8 +170,8 @@ void launchBranchSeedJob(String branch) {
     jobParams.add(stringParam(name: 'SEED_BRANCH', value: getEffectiveSeedBranch(branch)))
     jobParams.add(booleanParam(name: 'FORCE_REBUILD', value: true))
 
-    echo "Build ./${getBranchSeedJobName(branch)} with parameters ${jobParams}"
-    build(job: "./${getBranchSeedJobName(branch)}", parameters: jobParams, wait: false)
+    echo "Build ./${branch}/${getBranchSeedJobName(branch)} with parameters ${jobParams}"
+    build(job: "./${branch}/${getBranchSeedJobName(branch)}", parameters: jobParams, wait: false)
 }
 
 String getEffectiveSeedBranch(String branch) {

--- a/dsl/seed/jobs/scripts/util.groovy
+++ b/dsl/seed/jobs/scripts/util.groovy
@@ -48,6 +48,9 @@ def getRepoConfig(String repository, String generationBranch, String seedRepoPat
     def cfg = deepCopyObject(branchConfig)
     cfg.remove('repositories')
 
+    // In case repository is disabled
+    cfg.disabled = repoConfig.disabled ?: false
+
     cfg.git.branch = repoConfig.branch ?: generationBranch
     cfg.git.jenkins_config_path = repoConfig.jenkins_config_path ?: cfg.git.jenkins_config_path
 

--- a/dsl/seed/jobs/seed_job_branch.groovy
+++ b/dsl/seed/jobs/seed_job_branch.groovy
@@ -1,7 +1,13 @@
 // +++++++++++++++++++++++++++++++++++++++++++ create a seed job ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+import org.kie.jenkins.jobdsl.FolderUtils
+
+// Create all folders
+folder("${GENERATION_BRANCH}")
+FolderUtils.getAllNeededFolders().each { folder("${GENERATION_BRANCH}/${it}") }
+
 // Configuration of the seed and generated jobs is done via `dsl/seed/config.yaml`
-pipelineJob("${JOB_NAME}") {
+pipelineJob("${GENERATION_BRANCH}/${JOB_NAME}") {
     description("This job creates all needed Jenkins jobs on branch ${GENERATION_BRANCH}. DO NOT USE FOR TESTING !!!! See https://github.com/kiegroup/kogito-pipelines/blob/main/docs/jenkins.md#test-specific-jobs")
 
     logRotator {
@@ -34,10 +40,10 @@ pipelineJob("${JOB_NAME}") {
             scm {
                 git {
                     remote {
-                        url('https://github.com/${SEED_AUTHOR}/kogito-pipelines.git')
+                        url("https://github.com/${SEED_AUTHOR}/kogito-pipelines.git")
                         credentials('kie-ci')
                     }
-                    branch('${SEED_BRANCH}')
+                    branch("${SEED_BRANCH}")
                     extensions {
                         cleanBeforeCheckout()
                     }

--- a/dsl/seed/jobs/seed_job_main.groovy
+++ b/dsl/seed/jobs/seed_job_main.groovy
@@ -1,5 +1,13 @@
 // +++++++++++++++++++++++++++++++++++++++++++ create a seed job ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+String getSeedAuthor() {
+    return SEED_AUTHOR ?: 'kiegroup'
+}
+
+String getSeedBranch() {
+    return SEED_BRANCH ?: 'main'
+}
+
 // Configuration of the seed and generated jobs is done via `dsl/seed/config.yaml`
 pipelineJob('0-seed-job') {
     description('This job creates all needed Jenkins jobs. DO NOT USE FOR TESTING !!!! See https://github.com/kiegroup/kogito-pipelines/blob/main/docs/jenkins.md#test-specific-jobs')
@@ -30,8 +38,8 @@ pipelineJob('0-seed-job') {
         stringParam('CUSTOM_AUTHOR', '', 'To generate only some custom repos... Define from from which author the custom repositories are checked out. If none given, then `SEED_AUTHOR` is taken. Ignored if `CUSTOM_BRANCH_KEY` is not set.')
         stringParam('CUSTOM_MAIN_BRANCH', '', 'To generate only some custom repos... If no main_branch is given, then DSL config `git.main_branch` is taken. Ignored if `CUSTOM_BRANCH_KEY` is not set.')
 
-        stringParam('SEED_AUTHOR', 'kiegroup', 'If different from the default')
-        stringParam('SEED_BRANCH', 'main', 'If different from the default')
+        stringParam('SEED_AUTHOR', getSeedAuthor(), 'If different from the default')
+        stringParam('SEED_BRANCH', getSeedBranch(), 'If different from the default')
 
         booleanParam('FORCE_REBUILD', false, 'Default, the job will scan for modified files and do the update in case some files are modified. In case you want to force the DSL generation')
     }
@@ -41,10 +49,10 @@ pipelineJob('0-seed-job') {
             scm {
                 git {
                     remote {
-                        url('https://github.com/${SEED_AUTHOR}/kogito-pipelines.git')
+                        url("https://github.com/${getSeedAuthor()}/kogito-pipelines.git")
                         credentials('kie-ci')
                     }
-                    branch('${SEED_BRANCH}')
+                    branch(getSeedBranch())
                     extensions {
                         cleanBeforeCheckout()
                     }
@@ -55,7 +63,7 @@ pipelineJob('0-seed-job') {
     }
 
     properties {
-        githubProjectUrl("https://github.com/${SEED_AUTHOR}/kogito-pipelines/")
+        githubProjectUrl("https://github.com/${getSeedAuthor()}/kogito-pipelines/")
 
         pipelineTriggers {
             triggers {

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/FolderUtils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/FolderUtils.groovy
@@ -1,0 +1,48 @@
+
+package org.kie.jenkins.jobdsl
+
+class FolderUtils {
+
+    static String NIGHTLY_FOLDER = 'nightly'
+    static String RELEASE_FOLDER = 'release'
+    static String TOOLS_FOLDER = 'tools'
+    static String PULLREQUEST_FOLDER = 'pullrequest'
+    static String OTHER_FOLDER = 'other'
+    static String PULLREQUEST_RUNTIMES_BDD_FOLDER = "${PULLREQUEST_FOLDER}/kogito-runtimes.bdd"
+
+    static List getAllNeededFolders() {
+        return [
+            NIGHTLY_FOLDER,
+            RELEASE_FOLDER,
+            TOOLS_FOLDER,
+            PULLREQUEST_FOLDER,
+            PULLREQUEST_RUNTIMES_BDD_FOLDER,
+            OTHER_FOLDER,
+        ]
+    }
+
+    static String getNightlyFolder(def script) {
+        return NIGHTLY_FOLDER
+    }
+
+    static String getReleaseFolder(def script) {
+        return RELEASE_FOLDER
+    }
+
+    static String getToolsFolder(def script) {
+        return TOOLS_FOLDER
+    }
+
+    static String getPullRequestFolder(def script) {
+        return PULLREQUEST_FOLDER
+    }
+
+    static String getPullRequestRuntimesBDDFolder(def script) {
+        return PULLREQUEST_RUNTIMES_BDD_FOLDER
+    }
+
+    static String getOtherFolder(def script) {
+        return OTHER_FOLDER
+    }
+
+}

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoConstants.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoConstants.groovy
@@ -1,13 +1,6 @@
 package org.kie.jenkins.jobdsl
 
 class KogitoConstants {
-  static String KOGITO_DSL_NIGHTLY_FOLDER = 'nightly'
-  static String KOGITO_DSL_RELEASE_FOLDER = 'release'
-  static String KOGITO_DSL_TOOLS_FOLDER = 'tools'
-  static String KOGITO_DSL_PULLREQUEST_FOLDER = 'pullrequest'
-  static String KOGITO_DSL_OTHER_FOLDER = 'other'
-  static String KOGITO_DSL_RUNTIMES_BDD_FOLDER = 'kogito-runtimes.bdd'
-
   static String KOGITO_DEFAULT_PR_TRIGGER_PHRASE = '.*[j|J]enkins,?.*(retest|test) this.*'
   static String KOGITO_LTS_PR_TRIGGER_PHRASE = '.*[j|J]enkins,? run LTS[ tests]?.*'
   static String KOGITO_NATIVE_PR_TRIGGER_PHRASE = '.*[j|J]enkins,? run native[ tests]?.*'

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
@@ -6,15 +6,6 @@ import groovy.json.JsonOutput
 
 class Utils {
 
-    static def createFolderHierarchy(def script, String folderFullPath) {
-        String folderPath = ''
-        folderFullPath.split('/').findAll { it != '' }.each {
-            folderPath = folderPath ? "${folderPath}/${it}" : it
-            println "Create job folder ${folderPath}"
-            script.folder(folderPath)
-    }
-}
-
     static def deepCopyObject(def originalMap) {
         return new JsonSlurper().parseText(JsonOutput.toJson(originalMap))
     }
@@ -60,7 +51,7 @@ class Utils {
     static String getGitBranch(def script) {
         return getBindingValue(script, 'GIT_BRANCH')
     }
-    
+
     static String getGitMainBranch(def script) {
         return getBindingValue(script, 'GIT_MAIN_BRANCH')
     }
@@ -75,10 +66,6 @@ class Utils {
 
     static String getGitAuthorTokenCredsId(def script) {
         return getBindingValue(script, 'GIT_AUTHOR_TOKEN_CREDENTIALS_ID')
-    }
-
-    static String getJobBranchFolder(def script) {
-        return getBindingValue(script, 'JOB_BRANCH_FOLDER')
     }
 
     static String getJenkinsConfigPath(def script, String repoName) {

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/templates/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/templates/KogitoJobTemplate.groovy
@@ -2,6 +2,7 @@ package org.kie.jenkins.jobdsl.templates
 
 import org.kie.jenkins.jobdsl.KogitoConstants
 import org.kie.jenkins.jobdsl.RegexUtils
+import org.kie.jenkins.jobdsl.FolderUtils
 import org.kie.jenkins.jobdsl.Utils
 import org.kie.jenkins.jobdsl.VersionUtils
 
@@ -34,7 +35,6 @@ class KogitoJobTemplate {
     *
     */
     static def createPipelineJob(def script, Map jobParams = [:]) {
-        Utils.createFolderHierarchy(script, jobParams.job.folder)
         return script.pipelineJob("${jobParams.job.folder}/${jobParams.job.name}") {
             description("""
                         ${jobParams.job.description ?: jobParams.job.name} on branch ${jobParams.git.branch}\n
@@ -117,7 +117,7 @@ class KogitoJobTemplate {
         jobParams.pr = jobParams.pr ?: [:] // Setup default config for pr to avoid NullPointerException
 
         if (!jobParams.job.folder) {
-            jobParams.job.folder = "${KogitoConstants.KOGITO_DSL_PULLREQUEST_FOLDER}/${Utils.getJobBranchFolder(script)}"
+            jobParams.job.folder = FolderUtils.getPullRequestFolder(script)
         }
 
         return createPipelineJob(script, jobParams).with {

--- a/dsl/seed/src/test/groovy/org/kie/jenkins/jobdsl/JobScriptsSpec.groovy
+++ b/dsl/seed/src/test/groovy/org/kie/jenkins/jobdsl/JobScriptsSpec.groovy
@@ -9,6 +9,7 @@ import javaposse.jobdsl.dsl.GeneratedJob
 import javaposse.jobdsl.dsl.GeneratedView
 import javaposse.jobdsl.dsl.JobManagement
 import javaposse.jobdsl.plugin.JenkinsJobManagement
+import javaposse.jobdsl.dsl.Folder
 import jenkins.model.Jenkins
 import org.junit.ClassRule
 import org.jvnet.hudson.test.JenkinsRule
@@ -40,7 +41,6 @@ class JobScriptsSpec extends Specification {
         Map<String, ?> envVars = TestUtil.readBranchConfig()
         envVars.put('DEBUG', false)
         envVars.put('JOB_NAME', 'JOB_NAME')
-        envVars.put('JOB_BRANCH_FOLDER', 'seed_branch')
         envVars.put('GENERATION_BRANCH', 'GENERATION_BRANCH')
         envVars.put('REPO_NAME', 'REPO_NAME')
         envVars.put('GIT_MAIN_BRANCH', 'GIT_MAIN_BRANCH')
@@ -58,6 +58,12 @@ class JobScriptsSpec extends Specification {
 
         envVars.put('GIT_JENKINS_CONFIG_PATH', 'GIT_JENKINS_CONFIG_PATH')
         JobManagement jm = new JenkinsJobManagement(System.out, envVars, new File('.'))
+        jm.createOrUpdateConfig(new Folder(jm, 'nightly'), true)
+        jm.createOrUpdateConfig(new Folder(jm, 'release'), true)
+        jm.createOrUpdateConfig(new Folder(jm, 'tools'), true)
+        jm.createOrUpdateConfig(new Folder(jm, 'pullrequest'), true)
+        jm.createOrUpdateConfig(new Folder(jm, 'other'), true)
+        jm.createOrUpdateConfig(new Folder(jm, 'kogito-runtimes.bdd'), true)
 
         when:
         GeneratedItems items = new DslScriptLoader(jm).runScript(file.text)


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5730

This will reorganize the different jobs in a specific branch folder and allow automatically deleting jobs when the concerned branch is removed from the [main config](https://github.com/kiegroup/kogito-pipelines/blob/main/dsl/seed/config/main.yaml#L2)

Example: https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/custom/job/tradisso/job/kogito-5730/

Here are the new mappings: 
- nightly/{branch}/... => {branch}/nightly/...
- release/{branch}/... => {branch}/release/...
- pullrequest/{branch}/... => {branch}/pullrequest/...
- tools/{branch}/... => {branch}/tools/...
- other/{branch}/... => {branch}/other/...

**All PRs should be merged at the same time !!!!**

Dependent PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/237
- https://github.com/kiegroup/kogito-runtimes/pull/1538
- https://github.com/kiegroup/optaplanner/pull/1517
- https://github.com/kiegroup/kogito-apps/pull/990
- https://github.com/kiegroup/kogito-examples/pull/856
- https://github.com/kiegroup/kogito-images/pull/678
- https://github.com/kiegroup/kogito-operator/pull/987
- https://github.com/kiegroup/rhpam-kogito-operator/pull/68