### PR TITLE
KOGITO-5487 Enabled LTS checks

### DIFF
--- a/dsl/seed/config/branch.yaml
+++ b/dsl/seed/config/branch.yaml
@@ -1,8 +1,8 @@
 # Disabled until Quarkus 2.2 is out
 # Follow-up issue: https://issues.redhat.com/browse/KOGITO-5487
 lts:
-  enabled: false
-  quarkus_version: '1.11'
+  enabled: true
+  quarkus_version: '2.2'
   native_builder_image: quay.io/quarkus/ubi-quarkus-mandrel:21.1-java11
 
 disable:


### PR DESCRIPTION
Now that Quarkus 2.2 is out, we can enable the LTS checks against quarkus branch 2.2

https://issues.redhat.com/browse/KOGITO-5487