### PR TITLE
[KOGITO-5780] Set JDK and Maven tools as env vars

### DIFF
--- a/.ci/jenkins/Jenkinsfile.buildchain
+++ b/.ci/jenkins/Jenkinsfile.buildchain
@@ -2,8 +2,8 @@
 
 agentLabel = "${env.ADDITIONAL_LABEL?.trim() ?: 'kie-rhel7 && kie-mem16g'} && !master"
 timeoutValue = env.ADDITIONAL_TIMEOUT?.trim() ?: '180'
-jdkTool = env.BUILD_JDK_TOOL?.trim() ?: 'kie-jdk11'
-mavenTool = env.BUILD_MAVEN_TOOL?.trim() ?: 'kie-maven-3.8.1'
+jdkTool = env.BUILD_JDK_TOOL
+mavenTool = env.BUILD_MAVEN_TOOL
 
 prType = env.BUILDCHAIN_PR_TYPE?.trim() ?: 'pr'
 buildChainProject = env.BUILDCHAIN_PROJECT?.trim()

--- a/.ci/jenkins/Jenkinsfile.tools.update-dependency-version
+++ b/.ci/jenkins/Jenkinsfile.tools.update-dependency-version
@@ -8,8 +8,8 @@ pipeline {
     }
     
     tools {
-        maven 'kie-maven-3.8.1'
-        jdk 'kie-jdk11'
+        maven env.BUILD_MAVEN_TOOL
+        jdk env.BUILD_JDK_TOOL
     }
 
     options {

--- a/dsl/config/branch.yaml
+++ b/dsl/config/branch.yaml
@@ -59,3 +59,6 @@ cloud:
     latest_git_branch: main
 jenkins:
   email_creds_id: KOGITO_CI_EMAIL_TO
+  default_tools:
+    jdk: kie-jdk11
+    maven: kie-maven-3.8.1

--- a/dsl/seed/jobs/seed_job_main.groovy
+++ b/dsl/seed/jobs/seed_job_main.groovy
@@ -1,11 +1,13 @@
 // +++++++++++++++++++++++++++++++++++++++++++ create a seed job ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-import org.kie.jenkins.jobdsl.KogitoConstants
 import org.kie.jenkins.jobdsl.SeedJobUtils
 import org.kie.jenkins.jobdsl.Utils
 
+KOGITO_PIPELINES_REPOSITORY = 'kogito-pipelines'
+DEFAULT_CREDENTIALS_ID = 'kie-ci'
+
 String getSeedRepo() {
-    return Utils.getSeedRepo(this) ?: KogitoConstants.KOGITO_PIPELINES_REPOSITORY
+    return Utils.getSeedRepo(this) ?: KOGITO_PIPELINES_REPOSITORY
 }
 
 String getSeedAuthor() {
@@ -13,7 +15,7 @@ String getSeedAuthor() {
 }
 
 String getSeedAuthorCredsId() {
-    return Utils.getSeedAuthorCredsId(this) ?: KogitoConstants.DEFAULT_CREDENTIALS_ID
+    return Utils.getSeedAuthorCredsId(this) ?: DEFAULT_CREDENTIALS_ID
 }
 
 String getSeedBranch() {
@@ -21,7 +23,7 @@ String getSeedBranch() {
 }
 
 String getSeedConfigFileGitRepository() {
-    return SEED_CONFIG_FILE_GIT_REPOSITORY ?: KogitoConstants.KOGITO_PIPELINES_REPOSITORY
+    return SEED_CONFIG_FILE_GIT_REPOSITORY ?: KOGITO_PIPELINES_REPOSITORY
 }
 
 String getSeedConfigFileGitAuthorName() {
@@ -29,7 +31,7 @@ String getSeedConfigFileGitAuthorName() {
 }
 
 String getSeedConfigFileGitAuthorCredsId() {
-    return SEED_CONFIG_FILE_GIT_AUTHOR_CREDS_ID ?: KogitoConstants.DEFAULT_CREDENTIALS_ID
+    return SEED_CONFIG_FILE_GIT_AUTHOR_CREDS_ID ?: DEFAULT_CREDENTIALS_ID
 }
 
 String getSeedConfigFileGitBranch() {

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoConstants.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoConstants.groovy
@@ -3,10 +3,6 @@ package org.kie.jenkins.jobdsl
 class KogitoConstants {
 
     static String KOGITO_DEFAULT_PR_TRIGGER_PHRASE = '.*[j|J]enkins,?.*(retest|test) this.*'
-
-    static String KOGITO_PIPELINES_REPOSITORY = 'kogito-pipelines'
-    static String DEFAULT_CREDENTIALS_ID = 'kie-ci'
     
     static String SEED_JENKINSFILES_PATH = '.ci/jenkins'
-
 }

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
@@ -291,6 +291,7 @@ class KogitoJobTemplate {
             jobParams.job.folder = prFolder
             jobParams.env = jobParams.env ?: [:]
             jobParams.pr = jobParams.pr ?: [:]
+            KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(script, jobParams)
 
             // Kept for backward compatibility
             jobParams.job.name += testTypeId ? ".${testTypeId}" : ''

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobUtils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobUtils.groovy
@@ -54,6 +54,21 @@ class KogitoJobUtils {
         return jobParams
     }
 
+    static def setupJobParamsDefaultJDKConfiguration(def script, def jobParams) {
+        jobParams.env = jobParams.env ?: [:]
+        jobParams.env.putAll([
+            BUILD_JDK_TOOL: Utils.getJenkinsDefaultJDKTools(script),
+        ])
+    }
+
+    static def setupJobParamsDefaultMavenConfiguration(def script, def jobParams) {
+        jobParams.env = jobParams.env ?: [:]
+        setupJobParamsDefaultJDKConfiguration(script, jobParams)
+        jobParams.env.putAll([
+            BUILD_MAVEN_TOOL: Utils.getJenkinsDefaultMavenTools(script),
+        ])
+    }
+
     /**
     * Seed job params are used for `common` jenkinsfiles which are taken from the seed
     **/
@@ -68,6 +83,7 @@ class KogitoJobUtils {
 
     static def createVersionUpdateToolsJob(def script, String repository, String dependencyName, def mavenUpdate = [:], def gradleUpdate = [:], def filepathReplaceRegex = [:]) {
         def jobParams = getSeedJobParams(script, "update-${dependencyName.toLowerCase()}-${repository}", Folder.TOOLS, 'Jenkinsfile.tools.update-dependency-version', "Update ${dependencyName} version for ${repository}")
+        KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(script, jobParams)
         // Setup correct checkout branch for pipelines
         jobParams.env.putAll([
             REPO_NAME: "${repository}",

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
@@ -108,6 +108,18 @@ class Utils {
         return getBindingValue(script, 'JENKINS_EMAIL_CREDS_ID')
     }
 
+    static String getJenkinsDefaultTools(def script, String toolsName) {
+        return getBindingValue(script, "JENKINS_DEFAULT_TOOLS_${toolsName.toUpperCase()}")
+    }
+
+    static String getJenkinsDefaultJDKTools(def script) {
+        return getJenkinsDefaultTools(script, 'jdk')
+    }
+
+    static String getJenkinsDefaultMavenTools(def script) {
+        return getJenkinsDefaultTools(script, 'maven')
+    }
+
     static String getSeedRepo(def script) {
         return getBindingValue(script, 'SEED_REPO')
     }


### PR DESCRIPTION
Setup JDK and Maven tools as env variables

PR on other repos will come once that one is merged. It will be the same process.

Checks:
- [x] PRs
- [x] update-quarkus-version jobs

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/269
- https://github.com/kiegroup/drools/pull/4518
- https://github.com/kiegroup/kogito-runtimes/pull/1622
- https://github.com/kiegroup/kogito-apps/pull/1405
- https://github.com/kiegroup/kogito-examples/pull/1323
- https://github.com/kiegroup/kogito-operator/pull/1239
- https://github.com/kiegroup/optaplanner/pull/2061