### PR TITLE
[1.12.x] Fix/prod nightly/optaplanner branch 1.12.x

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -63,7 +63,7 @@ pipeline {
                             def SETTINGS_XML_ID = 'kogito-nightly-main'
                             def projectCollection = ['kogito-runtimes', 'optaplanner', 'kogito-examples', 'optaplanner-quickstarts', 'optaweb-vehicle-routing', 'optaweb-employee-rostering', 'jboss-integration/kogito-rhba']
                             def projectVariableMap = [:]
-                            def additionalVariables = ['optaplannerProductVersion': env.OPTAPLANNER_PRODUCT_VERSION, 'optaplanner-quickstarts-scmRevision': 'stable', 'rhbaProductVersion': env.RHBA_LASTEST_PRODUCT_VERSION]
+                            def additionalVariables = ['optaplannerProductVersion': env.OPTAPLANNER_PRODUCT_VERSION, 'optaplanner-scmRevision': getOptaplannerBranch(), 'optaplanner-quickstarts-scmRevision': getOptaPlannerBranch('stable'), 'rhbaProductVersion': env.RHBA_LASTEST_PRODUCT_VERSION]
                             configFileProvider([configFile(fileId: '49737697-ebd6-4396-9c22-11f7714808eb', variable: 'PRODUCTION_PROJECT_LIST')]) {
                                 pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/kogito/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
                             }
@@ -177,4 +177,18 @@ def getMessageBody(String propertiesFileUrl, String alreadyBuiltProjects) {
 
 def treatGitHashes(String gitInformationHashes) {
     return gitInformationHashes.replace('-', '.').replaceAll(/([\w\d\-\_\.]*\/)([\w\d\-\_\.]*)/,'$2.scm.hash').replace(';', '\n')
+}
+
+String getOptaPlannerBranch(String defaultBranch) {
+    /* The OptaPlanner major version is shifted by 7 from the Kogito major version:
+       Kogito 1.x.y -> OptaPlanner 8.x.y. */
+    int majorVersionShift = 7
+    def branch = defaultBranch ?: env.CHANGE_BRANCH ?: BRANCH_NAME
+
+    String [] branchSplit = branch.split("\\.")
+    if (branchSplit.length == 3) {
+        Integer optaplannerMajorVersion = Integer.parseInt(branchSplit[0]) + majorVersionShift
+        return "${optaplannerMajorVersion}.${branchSplit[1]}.${branchSplit[2]}"
+    }
+    return branch
 }


### PR DESCRIPTION
the optplanner branch is not properly taken for the `x.y.z` branch prod nightly jobs

- https://github.com/kiegroup/kogito-pipelines/pull/292
- https://github.com/kiegroup/kogito-pipelines/pull/293
- https://github.com/kiegroup/kogito-pipelines/pull/291