### PR TITLE
[1.11.x] Optaplanner quickstarts default branch should be `development`

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -64,7 +64,7 @@ pipeline {
                             def SETTINGS_XML_ID = RHBA_RELEASE_VERSION ? 'kogito-nightly-version' : 'kogito-nightly-main'
                             def projectCollection = ['kogito-runtimes', 'optaplanner', 'kogito-examples', 'optaplanner-quickstarts', 'optaweb-vehicle-routing', 'optaweb-employee-rostering', 'jboss-integration/kogito-rhba']
                             def projectVariableMap = [:]
-                            def additionalVariables = ['optaplannerProductVersion': env.OPTAPLANNER_PRODUCT_VERSION, 'optaplanner-scmRevision': getOptaPlannerBranch(), 'optaplanner-quickstarts-scmRevision': getOptaPlannerBranch('stable'), 'rhbaProductVersion': env.RHBA_LASTEST_PRODUCT_VERSION]
+                            def additionalVariables = ['optaplannerProductVersion': env.OPTAPLANNER_PRODUCT_VERSION, 'optaplanner-scmRevision': getOptaPlannerBranch('main'), 'optaplanner-quickstarts-scmRevision': getOptaPlannerBranch('development'), 'rhbaProductVersion': env.RHBA_LASTEST_PRODUCT_VERSION]
                             configFileProvider([configFile(fileId: '49737697-ebd6-4396-9c22-11f7714808eb', variable: 'PRODUCTION_PROJECT_LIST')]) {
                                 pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/kogito/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
                             }
@@ -180,11 +180,11 @@ def treatGitHashes(String gitInformationHashes) {
     return gitInformationHashes.replace('-', '.').replaceAll(/([\w\d\-\_\.]*\/)([\w\d\-\_\.]*)/,'$2.scm.hash').replace(';', '\n')
 }
 
-String getOptaPlannerBranch(String defaultBranch = '') {
+String getOptaPlannerBranch(String defaultBranch) {
     /* The OptaPlanner major version is shifted by 7 from the Kogito major version:
        Kogito 1.x.y -> OptaPlanner 8.x.y. */
     int majorVersionShift = 7
-    def branch = defaultBranch ?: env.CHANGE_BRANCH ?: BRANCH_NAME
+    def branch = env.CHANGE_BRANCH ?: BRANCH_NAME ?: defaultBranch
 
     String [] branchSplit = branch.split("\\.")
     if (branchSplit.length == 3) {

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -64,7 +64,7 @@ pipeline {
                             def SETTINGS_XML_ID = RHBA_RELEASE_VERSION ? 'kogito-nightly-version' : 'kogito-nightly-main'
                             def projectCollection = ['kogito-runtimes', 'optaplanner', 'kogito-examples', 'optaplanner-quickstarts', 'optaweb-vehicle-routing', 'optaweb-employee-rostering', 'jboss-integration/kogito-rhba']
                             def projectVariableMap = [:]
-                            def additionalVariables = ['optaplannerProductVersion': env.OPTAPLANNER_PRODUCT_VERSION, 'optaplanner-scmRevision': getOptaPlannerBranch('main'), 'optaplanner-quickstarts-scmRevision': getOptaPlannerBranch('development'), 'rhbaProductVersion': env.RHBA_LASTEST_PRODUCT_VERSION]
+                            def additionalVariables = ['optaplannerProductVersion': env.OPTAPLANNER_PRODUCT_VERSION, 'optaplanner-scmRevision': getOptaPlannerBranch(), 'optaplanner-quickstarts-scmRevision': getOptaPlannerQuickstartsBranch(), 'rhbaProductVersion': env.RHBA_LASTEST_PRODUCT_VERSION]
                             configFileProvider([configFile(fileId: '49737697-ebd6-4396-9c22-11f7714808eb', variable: 'PRODUCTION_PROJECT_LIST')]) {
                                 pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/kogito/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
                             }
@@ -180,16 +180,25 @@ def treatGitHashes(String gitInformationHashes) {
     return gitInformationHashes.replace('-', '.').replaceAll(/([\w\d\-\_\.]*\/)([\w\d\-\_\.]*)/,'$2.scm.hash').replace(';', '\n')
 }
 
-String getOptaPlannerBranch(String defaultBranch) {
-    /* The OptaPlanner major version is shifted by 7 from the Kogito major version:
-       Kogito 1.x.y -> OptaPlanner 8.x.y. */
-    int majorVersionShift = 7
-    def branch = env.CHANGE_BRANCH ?: BRANCH_NAME ?: defaultBranch
+String getOptaPlannerBranch() {
+    def branch = calculateOptaplannerRepoBranch(env.CHANGE_BRANCH ?: BRANCH_NAME)
+    return branch
+}
 
+String getOptaPlannerQuickstartsBranch() {
+    def branch = calculateOptaplannerRepoBranch(env.CHANGE_BRANCH ?: BRANCH_NAME)
+    return branch == 'main' ? 'development' : branch
+}
+
+String calculateOptaplannerRepoBranch(String branch) {
+    /* The OptaPlanner major version is shifted by 7 from the Kogito major version:
+    Kogito 1.x.y -> OptaPlanner 8.x.y. */
+    int majorVersionShift = 7
     String [] branchSplit = branch.split("\\.")
     if (branchSplit.length == 3) {
         Integer optaplannerMajorVersion = Integer.parseInt(branchSplit[0]) + majorVersionShift
         return "${optaplannerMajorVersion}.${branchSplit[1]}.${branchSplit[2]}"
+    } else {
+       return branch
     }
-    return branch
 }

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -181,8 +181,7 @@ def treatGitHashes(String gitInformationHashes) {
 }
 
 String getOptaPlannerBranch() {
-    def branch = calculateOptaplannerRepoBranch(env.CHANGE_BRANCH ?: BRANCH_NAME)
-    return branch
+    return calculateOptaplannerRepoBranch(env.CHANGE_BRANCH ?: BRANCH_NAME)
 }
 
 String getOptaPlannerQuickstartsBranch() {

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -187,7 +187,6 @@ String getOptaPlannerBranch() {
 String getOptaPlannerQuickstartsBranch() {
     def branch = env.CHANGE_BRANCH ?: BRANCH_NAME
     return branch == 'main' ? 'development' : calculateOptaplannerRepoBranch(branch)
-    return branch == 'main' ? 'development' : branch
 }
 
 String calculateOptaplannerRepoBranch(String branch) {

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -185,7 +185,8 @@ String getOptaPlannerBranch() {
 }
 
 String getOptaPlannerQuickstartsBranch() {
-    def branch = calculateOptaplannerRepoBranch(env.CHANGE_BRANCH ?: BRANCH_NAME)
+    def branch = env.CHANGE_BRANCH ?: BRANCH_NAME
+    return branch == 'main' ? 'development' : calculateOptaplannerRepoBranch(branch)
     return branch == 'main' ? 'development' : branch
 }
 


### PR DESCRIPTION
and it should be used only as a fallback