### PR TITLE
Updated timeout value for native checks

### DIFF
--- a/.ci/jenkins/Jenkinsfile.buildchain
+++ b/.ci/jenkins/Jenkinsfile.buildchain
@@ -117,7 +117,7 @@ String getAgentLabel() {
 }
 
 String getTimeoutValue() {
-    return "${env.ADDITIONAL_TIMEOUT?.trim() ?: (isNative() ? 360 : 180)}"
+    return "${env.ADDITIONAL_TIMEOUT?.trim() ?: (isNative() ? 720 : 180)}"
 }
 
 String getJdkTool() {


### PR DESCRIPTION
Because native is quite expensive... Some repos need more than 360 minutes