### PR TITLE
[1.11.x] default_config_branch renamed

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -16,7 +16,7 @@ pipeline {
         string(description: 'The UMB message version', name: 'UMB_VERSION', defaultValue: 'main')
         string(description: 'The product version', name: 'PRODUCT_VERSION')
         string(description: 'The optaplanner product version', name: 'OPTAPLANNER_PRODUCT_VERSION')
-        string(description: 'The config repository branch', name: 'DEFAULT_CONFIG_BRANCH', defaultValue: 'main')
+        string(description: 'The config repository branch', name: 'CONFIG_BRANCH', defaultValue: 'main')
         string(description: 'The RHBA release version. Something like 7.12 or main', name: 'RHBA_RELEASE_VERSION')
     }
     options {
@@ -34,7 +34,7 @@ pipeline {
         stage('Clone build configuration repo') {
             steps {
                 script {
-                    def currentBranch = env.DEFAULT_CONFIG_BRANCH ?: env.BRANCH_NAME ?: env.GIT_BRANCH
+                    def currentBranch = env.CONFIG_BRANCH ?: env.DEFAULT_CONFIG_BRANCH ?: env.BRANCH_NAME ?: env.GIT_BRANCH
                     println "Checking out ${env.BUILD_CONFIGURATION_REPO_URL}:${currentBranch} into build_config folder"
                     sh "git clone -b ${currentBranch} --single-branch ${env.BUILD_CONFIGURATION_REPO_URL} build_config"
                 }


### PR DESCRIPTION
we will use the branch from 7.59.x or whatever the branch we create for RHBA on build-configurations repository

Referenced PRs:

-  https://github.com/kiegroup/kie-jenkins-scripts/pull/1163
- https://github.com/kiegroup/kie-jenkins-scripts/pull/1163
- https://github.com/kiegroup/kogito-pipelines/pull/318
