### PR TITLE
Remove branch 1.12.x for Jenkins jobs

### DIFF
--- a/dsl/seed/config/main.yaml
+++ b/dsl/seed/config/main.yaml
@@ -2,7 +2,6 @@ git:
   branches:
   - main
   - 1.11.x
-  - 1.12.x
   - 1.13.x
   - 1.14.x
   main_branch:


### PR DESCRIPTION
as 1.13.x has been released, we won't maintain 1.12.x anymore