### PR TITLE
dependency:tree added to CI

### DIFF
--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -3,7 +3,7 @@ version: "2.1"
 dependencies: ./project-dependencies.yaml
 
 pre: |
-  export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -nsu -ntp -fae -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3"
+  export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -nsu -ntp -fae -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false dependency:tree -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3"
   echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
 
 default:

--- a/.ci/pull-request-lts-config.yaml
+++ b/.ci/pull-request-lts-config.yaml
@@ -3,7 +3,7 @@ version: "2.1"
 dependencies: ./project-dependencies-quarkus.yaml
 
 pre: |
-  export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -nsu -ntp -fae -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3"
+  export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -nsu -ntp -fae -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false dependency:tree -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3"
   echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
   export BUILD_MVN_OPTS_CURRENT="${{ env.BUILD_MVN_OPTS_CURRENT }} -Dversion.io.quarkus=999-SNAPSHOT"
   echo "BUILD_MVN_OPTS_CURRENT=${{ env.BUILD_MVN_OPTS_CURRENT }}"


### PR DESCRIPTION
- `dependency:tree` added to every maven command 
- common maven options moved to `BUILD_MVN_OPTS` variable.

Thanks to `dependecy:tree` info we can take profit of future maven build logs thanks to https://github.com/Ginxo/treat-maven-dependency-plugin-log tool and to analyze changes impact faster and in a more reliable way.

Related PR:

- https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/1853
- https://github.com/kiegroup/kogito-pipelines/pull/342

