### PR TITLE
BXMSPROD-1231 UMB message body with project version

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -184,7 +184,7 @@ def getMessageBody(String propertiesFileUrl, Map pmeExecutionResult) {
     return """
 {
 	"propertiesFileUrl": "${propertiesFileUrl}",
-	"builtProjects": ${new groovy.json.JsonBuilder(pmeExecutionResult).toString()}
+	"builtProjects": ${new groovy.json.JsonBuilder(pmeExecutionResult.collect{ it.key }).toString()}
 }"""
 }
 

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -67,6 +67,7 @@ pipeline {
                             configFileProvider([configFile(fileId: '49737697-ebd6-4396-9c22-11f7714808eb', variable: 'PRODUCTION_PROJECT_LIST')]) {
                                 PME_EXECUTION_RESULT = pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/kogito/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
                             }
+                            println "[INFO] PME_EXECUTION_RESULT: ${PME_EXECUTION_RESULT}"
                         }, 2, 480*60)
                     }
                 }
@@ -96,7 +97,7 @@ pipeline {
         stage('Upload Files to repository') {
             steps {
                 script {
-                    if(PME_EXECUTION_RESULT?.filter{ it.value != null }.size()) {
+                    if(PME_EXECUTION_RESULT?.findAll{ it.value != null }.size()) {
                         echo "[INFO] Start uploading ${env.WORKSPACE}/deployDirectory"
                         if(fileExists("${env.WORKSPACE}/deployDirectory")){
                             dir("${env.WORKSPACE}/deployDirectory") {

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -1,5 +1,8 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
+PME_EXECUTION_RESULT = [:]
+
+
 pipeline {
     agent {
         label 'kie-rhel7 && kie-mem24g && !master'
@@ -62,7 +65,7 @@ pipeline {
                                 'optaweb-employee-rostering-scmRevision': getOptaPlannerBranch(),
                             ]
                             configFileProvider([configFile(fileId: '49737697-ebd6-4396-9c22-11f7714808eb', variable: 'PRODUCTION_PROJECT_LIST')]) {
-                                pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/kogito/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
+                                PME_EXECUTION_RESULT = pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/kogito/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
                             }
                         }, 2, 480*60)
                     }
@@ -72,7 +75,7 @@ pipeline {
         stage('Generate Properties Files') {
             steps {
                 script {
-                    if(env.ALREADY_BUILT_PROJECTS?.trim()) {
+                    if(PME_EXECUTION_RESULT?.size()) {
                         def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
 
                         build job: env.KOGITO_PROPERTIES_GENERATOR_PATH, parameters: [
@@ -93,7 +96,7 @@ pipeline {
         stage('Upload Files to repository') {
             steps {
                 script {
-                    if(env.ALREADY_BUILT_PROJECTS?.trim()) {
+                    if(PME_EXECUTION_RESULT?.filter{ it.value != null }.size()) {
                         echo "[INFO] Start uploading ${env.WORKSPACE}/deployDirectory"
                         if(fileExists("${env.WORKSPACE}/deployDirectory")){
                             dir("${env.WORKSPACE}/deployDirectory") {
@@ -112,14 +115,14 @@ pipeline {
         stage ('Send UMB Message to QE.') {
             steps {
                 script {
-                    if(env.ALREADY_BUILT_PROJECTS?.trim()) {
+                    if(PME_EXECUTION_RESULT?.size()) {
                         echo '[INFO] Sending KOGITO UMB message to QE.'
                         def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
 
                         def propertiesFileUrl = "${env.STAGING_SERVER_URL}/kogito/KOGITO-${PME_BUILD_VARIABLES['productVersion']}.${PME_BUILD_VARIABLES['milestone']}/kogito-${PME_BUILD_VARIABLES['datetimeSuffix']}.properties"
                         def topic = "VirtualTopic.qe.ci.ba.kogito.${env.UMB_VERSION}.nightly.trigger"
                         def eventType = "kogito-${env.UMB_VERSION}-nightly-qe-trigger"
-                        def messageBody = getMessageBody(propertiesFileUrl, env.ALREADY_BUILT_PROJECTS)
+                        def messageBody = getMessageBody(propertiesFileUrl, PME_EXECUTION_RESULT)
                         echo "[INFO] Message Body: ${messageBody}"
                         echo "[INFO] Topic: ${topic}"
                         echo "[INFO] Event Type: ${eventType}"
@@ -170,13 +173,18 @@ pipeline {
     }
 }
 
-def getMessageBody(String propertiesFileUrl, String alreadyBuiltProjects) { 
-    def alreadyBuiltProjectsArray = (alreadyBuiltProjects ?: '').split(";")
+/**
+ * 
+ * @param propertiesFileUrl the propertiesFile URL
+ * @param pmeExecutionResult the PME execution map [projectName: projectVersion]
+ * @return the UMB message body composed the propertiesFileUrl and the builtProjects containing the projectName: projectVersion map 
+ */
+def getMessageBody(String propertiesFileUrl, Map pmeExecutionResult) {
     return """
 {
 	"propertiesFileUrl": "${propertiesFileUrl}",
-	"builtProjects": ${new groovy.json.JsonBuilder(alreadyBuiltProjectsArray).toString()}
-}"""    
+	"builtProjects": ${new groovy.json.JsonBuilder(pmeExecutionResult).toString()}
+}"""
 }
 
 def treatGitHashes(String gitInformationHashes) {


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1231

- https://github.com/kiegroup/kogito-pipelines/pull/344
- https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/180

@radtriste just consider to change the QE side consuming the UMB message
from `builtProjects: ['projectA', 'projectB']` to `builtProjects: {'projectA': 'versionX', 'projectB': 'versionY'}` 