### PR TITLE
BXMSPROD-1603 GHA actions: Updated setup maven and java

### DIFF
--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -16,12 +16,16 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Setup Maven And Java Version
-      uses: s4u/setup-maven-action@v1.2.1
+    - name: Setup Jdk
+      uses: actions/setup-java@v2
       with:
+        distribution: 'temurin'
         java-version: ${{ inputs.java-version }}
+        check-latest: true
+    - name: Set up Maven
+      uses: stCarolas/setup-maven@v4.2
+      with:
         maven-version: ${{ inputs.maven-version }}
-    # See https://docs.github.com/en/actions/guides/building-and-testing-java-with-maven#caching-dependencies
     - name: Cache Maven packages
       uses: actions/cache@v2
       with:


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1603

There was conflict using https://github.com/s4u/setup-maven-action with kogito-runtimes. This is a modified version of the `Setup Maven and Java` action

- Fallback to setup JDK (with upgrade to v2)
- Added setup Maven
- Keep cache
