### PR TITLE
PLANNER-2641 OptaPlanner depends on Drools, not Kogito

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -84,26 +84,6 @@ pipeline {
             }
         }
 
-        stage('Build & Deploy Kogito Runtimes') {
-            when {
-                expression { return isArtifactsDeploy() }
-            }
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams()
-                    addSkipTestsParam(buildParams)
-
-                    // images and operator deploy testing will use older working artifacts if that one fails
-                    buildJob(RUNTIMES_DEPLOY, buildParams)
-                }
-            }
-            post {
-                failure {
-                    addFailedStage(RUNTIMES_DEPLOY)
-                }
-            }
-        }
-
         stage('Build & Deploy OptaPlanner') {
             when {
                 expression { return isArtifactsDeploy() }
@@ -133,6 +113,26 @@ pipeline {
             post {
                 failure {
                     addFailedStage(OPTAPLANNER_DEPLOY)
+                }
+            }
+        }
+
+        stage('Build & Deploy Kogito Runtimes') {
+            when {
+                expression { return isArtifactsDeploy() }
+            }
+            steps {
+                script {
+                    def buildParams = getDefaultBuildParams()
+                    addSkipTestsParam(buildParams)
+
+                    // images and operator deploy testing will use older working artifacts if that one fails
+                    buildJob(RUNTIMES_DEPLOY, buildParams)
+                }
+            }
+            post {
+                failure {
+                    addFailedStage(RUNTIMES_DEPLOY)
                 }
             }
         }

--- a/.ci/jenkins/Jenkinsfile.pr.bdd-tests
+++ b/.ci/jenkins/Jenkinsfile.pr.bdd-tests
@@ -50,23 +50,6 @@ pipeline {
             }
         }
 
-        stage('Build & Deploy Kogito Runtimes') {
-            steps {
-                script {
-                    echo "Call ${RUNTIMES_DEPLOY} job"
-                    def buildParams = getDefaultBuildParams()
-                    addAuthorBranchParamsIfExist(buildParams, 'kogito-runtimes')
-
-                    buildJob(RUNTIMES_DEPLOY, buildParams, false)
-                }
-            }
-            post {
-                failure {
-                    addFailedStage()
-                }
-            }
-        }
-
         stage('Build & Deploy OptaPlanner') {
             steps {
                 script {
@@ -79,6 +62,23 @@ pipeline {
                     addStringParam(buildParams, 'QUICKSTARTS_BUILD_BRANCH_NAME', targetBranch)
 
                     buildJob(OPTAPLANNER_DEPLOY, buildParams, false)
+                }
+            }
+            post {
+                failure {
+                    addFailedStage()
+                }
+            }
+        }
+
+        stage('Build & Deploy Kogito Runtimes') {
+            steps {
+                script {
+                    echo "Call ${RUNTIMES_DEPLOY} job"
+                    def buildParams = getDefaultBuildParams()
+                    addAuthorBranchParamsIfExist(buildParams, 'kogito-runtimes')
+
+                    buildJob(RUNTIMES_DEPLOY, buildParams, false)
                 }
             }
             post {

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -50,7 +50,7 @@ pipeline {
                         pipelineHelper.retry(
                         {
                             def SETTINGS_XML_ID = RHBA_RELEASE_VERSION ? 'kogito-nightly-version' : 'kogito-nightly-main'
-                            def projectCollection = ['drools', 'kogito-runtimes', 'optaplanner', 'kogito-examples', 'optaplanner-quickstarts', 'optaweb-vehicle-routing', 'optaweb-employee-rostering', 'jboss-integration/kogito-rhba']
+                            def projectCollection = ['drools', 'optaplanner', 'optaplanner-quickstarts', 'optaweb-vehicle-routing', 'optaweb-employee-rostering', 'kogito-runtimes', 'kogito-examples', 'jboss-integration/kogito-rhba']
                             def projectVariableMap = [:]
                             def additionalVariables = [
                                 'droolsProductVersion': env.DROOLS_PRODUCT_VERSION, 

--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -109,6 +109,22 @@ pipeline {
             }
         }
 
+        stage('Build & Deploy OptaPlanner') {
+            when {
+                expression { return isArtifactsDeploy() }
+            }
+            steps {
+                script {
+                    def buildParams = getDefaultBuildParams(getOptaPlannerVersion())
+                    addSkipTestsParam(buildParams)
+                    addSkipIntegrationTestsParam(buildParams)
+                    addStringParam(buildParams, 'DROOLS_VERSION', getDroolsVersion())
+                    addStringParam(buildParams, 'QUICKSTARTS_BUILD_BRANCH_NAME', getOptaPlannerReleaseBranch())
+                    buildJob(OPTAPLANNER_DEPLOY, buildParams)
+                }
+            }
+        }
+
         stage('Build & Deploy Kogito Runtimes') {
             when {
                 expression { return isArtifactsDeploy() }
@@ -120,22 +136,6 @@ pipeline {
                     addStringParam(buildParams, 'DROOLS_VERSION', getDroolsVersion())
 
                     buildJob(RUNTIMES_DEPLOY, buildParams)
-                }
-            }
-        }
-
-        stage('Build & Deploy OptaPlanner') {
-            when {
-                expression { return isArtifactsDeploy() }
-            }
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams(getOptaPlannerVersion())
-                    addSkipTestsParam(buildParams)
-                    addSkipIntegrationTestsParam(buildParams)
-                    addStringParam(buildParams, 'KOGITO_VERSION', getKogitoArtifactsVersion())
-                    addStringParam(buildParams, 'QUICKSTARTS_BUILD_BRANCH_NAME', getOptaPlannerReleaseBranch())
-                    buildJob(OPTAPLANNER_DEPLOY, buildParams)
                 }
             }
         }
@@ -302,6 +302,21 @@ pipeline {
             }
         }
 
+        stage('Promote OptaPlanner') {
+            when {
+                expression { return isArtifactsPromote() && isJobConsideredOk(OPTAPLANNER_DEPLOY) }
+            }
+            steps {
+                script {
+                    def buildParams = getDefaultBuildParams(getOptaPlannerVersion())
+                    addDeployBuildUrlParam(buildParams, OPTAPLANNER_DEPLOY)
+                    addStringParam(buildParams, 'DROOLS_VERSION', getDroolsVersion())
+
+                    buildJob(OPTAPLANNER_PROMOTE, buildParams)
+                }
+            }
+        }
+
         stage('Promote Kogito Runtimes') {
             when {
                 expression { return isArtifactsPromote() && isJobConsideredOk(RUNTIMES_DEPLOY) }
@@ -313,21 +328,6 @@ pipeline {
                     addStringParam(buildParams, 'DROOLS_VERSION', getDroolsVersion())
 
                     buildJob(RUNTIMES_PROMOTE, buildParams)
-                }
-            }
-        }
-
-        stage('Promote OptaPlanner') {
-            when {
-                expression { return isArtifactsPromote() && isJobConsideredOk(OPTAPLANNER_DEPLOY) }
-            }
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams(getOptaPlannerVersion())
-                    addDeployBuildUrlParam(buildParams, OPTAPLANNER_DEPLOY)
-                    addStringParam(buildParams, 'KOGITO_VERSION', getKogitoArtifactsVersion())
-
-                    buildJob(OPTAPLANNER_PROMOTE, buildParams)
                 }
             }
         }

--- a/.ci/jenkins/Jenkinsfile.release.prepare
+++ b/.ci/jenkins/Jenkinsfile.release.prepare
@@ -37,22 +37,22 @@ pipeline {
             steps {
                 script {
                     assert getDroolsVersion()
-                    assert getKogitoVersion()
                     assert getOptaPlannerVersion()
+                    assert getKogitoVersion()
 
                     // Set release branch
                     env.DROOLS_RELEASE_BRANCH = util.getReleaseBranchFromVersion(getDroolsVersion())
                     echo "Drools Release Branch ${getDroolsReleaseBranch()}"
 
-                    env.KOGITO_RELEASE_BRANCH = util.getReleaseBranchFromVersion(getKogitoVersion())
-                    echo "Kogito Release Branch ${getKogitoReleaseBranch()}"
-
                     env.OPTAPLANNER_RELEASE_BRANCH = util.getReleaseBranchFromVersion(getOptaPlannerVersion())
                     echo "OptaPlanner Release Branch ${getOptaPlannerReleaseBranch()}"
 
-                    currentBuild.displayName = getDisplayName("Drools ${getDroolsReleaseBranch()} / Kogito ${getKogitoReleaseBranch()}/ OptaPlanner${getOptaPlannerReleaseBranch()}")
+                    env.KOGITO_RELEASE_BRANCH = util.getReleaseBranchFromVersion(getKogitoVersion())
+                    echo "Kogito Release Branch ${getKogitoReleaseBranch()}"
 
-                    sendNotification("Cut-off for Drools ${getDroolsReleaseBranch()}, Kogito ${getKogitoReleaseBranch()} and Optaplanner ${getOptaPlannerReleaseBranch()} has started...\n=> ${env.BUILD_URL}")
+                    currentBuild.displayName = getDisplayName("Drools ${getDroolsReleaseBranch()} / OptaPlanner${getOptaPlannerReleaseBranch()} / Kogito ${getKogitoReleaseBranch()}")
+
+                    sendNotification("Cut-off for Drools ${getDroolsReleaseBranch()}, Optaplanner ${getOptaPlannerReleaseBranch()} and Kogito ${getKogitoReleaseBranch()} has started...\n=> ${env.BUILD_URL}")
                 }
             }
         }
@@ -71,6 +71,19 @@ pipeline {
             }
         }
 
+        stage('Create OptaPlanner release branches') {
+            steps {
+                script {
+                    def repositories = OPTAPLANNER_REPOS
+
+                    echo "Create ${getOptaPlannerReleaseBranch()} on repositories ${repositories}"
+                    createBranches(repositories, getOptaPlannerReleaseBranch())
+
+                    sendNotification("${getOptaPlannerReleaseBranch()} branches have been created for repositories: ${repositories}")
+                }
+            }
+        }
+
         stage('Create Kogito release branches') {
             steps {
                 script {
@@ -84,19 +97,6 @@ pipeline {
                     createBranches(repositories, getKogitoReleaseBranch())
 
                     sendNotification("${getKogitoReleaseBranch()} branches have been created for repositories: ${repositories}")
-                }
-            }
-        }
-
-        stage('Create OptaPlanner release branches') {
-            steps {
-                script {
-                    def repositories = OPTAPLANNER_REPOS
-
-                    echo "Create ${getOptaPlannerReleaseBranch()} on repositories ${repositories}"
-                    createBranches(repositories, getOptaPlannerReleaseBranch())
-
-                    sendNotification("${getOptaPlannerReleaseBranch()} branches have been created for repositories: ${repositories}")
                 }
             }
         }

--- a/.ci/jenkins/Jenkinsfile.tools.update-quarkus
+++ b/.ci/jenkins/Jenkinsfile.tools.update-quarkus
@@ -29,7 +29,7 @@ pipeline {
         stage('Call update quarkus jobs') {
             steps {
                 script {
-                    [ 'kogito-runtimes', 'kogito-examples', 'optaplanner', 'optaplanner-quickstarts' ].each { repo ->
+                    [ 'optaplanner', 'optaplanner-quickstarts', 'kogito-runtimes', 'kogito-examples' ].each { repo ->
                         launchUpdateQuarkusJob(repo)
                     }
                 }

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -142,11 +142,11 @@ void setupReleaseJob() {
 
             stringParam('DROOLS_VERSION', '', 'Drools version to release as Major.minor.micro')
             stringParam('DROOLS_RELEASE_BRANCH', '', '(optional) Use to override the release branch name deduced from the DROOLS_VERSION')
+            stringParam('OPTAPLANNER_VERSION', '', 'Project version of OptaPlanner and its examples to release as Major.minor.micro')
+            stringParam('OPTAPLANNER_RELEASE_BRANCH', '', '(optional) Use to override the release branch name deduced from the OPTAPLANNER_VERSION')
             stringParam('KOGITO_VERSION', '', 'Kogito version to release as Major.minor.micro')
             stringParam('KOGITO_IMAGES_VERSION', '', '(optional) To be set if different from KOGITO_VERSION. Should be only a bug fix update from KOGITO_VERSION.')
             stringParam('KOGITO_OPERATOR_VERSION', '', '(optional) To be set if different from KOGITO_VERSION. Should be only a bug fix update from KOGITO_VERSION.')
-            stringParam('OPTAPLANNER_VERSION', '', 'Project version of OptaPlanner and its examples to release as Major.minor.micro')
-            stringParam('OPTAPLANNER_RELEASE_BRANCH', '', '(optional) Use to override the release branch name deduced from the OPTAPLANNER_VERSION')
             booleanParam('DEPLOY_AS_LATEST', false, 'Given project version is considered the latest version')
 
             booleanParam('SKIP_TESTS', false, 'Skip all tests')
@@ -187,8 +187,8 @@ void setupPrepareReleaseJob() {
     KogitoJobTemplate.createPipelineJob(this, getJobParams('prepare-release-branch', FolderUtils.getReleaseFolder(this), "${JENKINSFILE_PATH}/Jenkinsfile.release.prepare", 'Prepare env for a release')).with {
         parameters {
             stringParam('DROOLS_VERSION', '', 'Drools version to release as Major.minor.micro')
-            stringParam('KOGITO_VERSION', '', 'Kogito version to release as Major.minor.micro')
             stringParam('OPTAPLANNER_VERSION', '', 'OptaPlanner version of OptaPlanner and its examples to release as Major.minor.micro')
+            stringParam('KOGITO_VERSION', '', 'Kogito version to release as Major.minor.micro')
         }
 
         environmentVariables {

--- a/.ci/project-dependencies-quarkus.yaml
+++ b/.ci/project-dependencies-quarkus.yaml
@@ -24,6 +24,25 @@ dependencies:
         - kiegroup/optaweb-vehicle-routing
         - kiegroup/optaplanner-quickstarts
 
+  - project: kiegroup/optaplanner
+    dependencies:
+      - project: kiegroup/drools
+    mapping:
+      dependencies:
+        default:
+          - source: (\d*)\.(.*)\.(.*)
+            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1-7}.${n2}.${n3}`)"
+      dependant:
+        default:
+          - source: (\d*)\.(.*)\.(.*)
+            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1+7}.${n2}.${n3}`)"
+      exclude:
+        - quarkusio/quarkus
+        - kiegroup/drools
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaweb-vehicle-routing
+        - kiegroup/optaplanner-quickstarts
+
   - project: kiegroup/kogito-runtimes
     dependencies:
       - project: quarkusio/quarkus
@@ -42,25 +61,6 @@ dependencies:
         - kiegroup/kogito-examples
         - kiegroup/kogito-apps
   
-  - project: kiegroup/optaplanner
-    dependencies:
-      - project: kiegroup/kogito-runtimes
-    mapping:
-      dependencies:
-        default:
-          - source: (\d*)\.(.*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1-7}.${n2}.${n3}`)"
-      dependant:
-        default:
-          - source: (\d*)\.(.*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1+7}.${n2}.${n3}`)"
-      exclude:
-        - quarkusio/quarkus
-        - kiegroup/drools
-        - kiegroup/optaweb-employee-rostering
-        - kiegroup/optaweb-vehicle-routing
-        - kiegroup/optaplanner-quickstarts
-
   - project: kiegroup/kogito-apps
     dependencies:
       - project: kiegroup/kogito-runtimes

--- a/.ci/project-dependencies-quarkus.yaml
+++ b/.ci/project-dependencies-quarkus.yaml
@@ -39,6 +39,7 @@ dependencies:
             targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1+7}.${n2}.${n3}`)"
       exclude:
         - quarkusio/quarkus
+        - kiegroup/drools
         - kiegroup/optaweb-employee-rostering
         - kiegroup/optaweb-vehicle-routing
         - kiegroup/optaplanner-quickstarts

--- a/.ci/project-dependencies-quarkus.yaml
+++ b/.ci/project-dependencies-quarkus.yaml
@@ -26,6 +26,7 @@ dependencies:
 
   - project: kiegroup/optaplanner
     dependencies:
+      - project: quarkusio/quarkus
       - project: kiegroup/drools
     mapping:
       dependencies:
@@ -38,7 +39,6 @@ dependencies:
             targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1+7}.${n2}.${n3}`)"
       exclude:
         - quarkusio/quarkus
-        - kiegroup/drools
         - kiegroup/optaweb-employee-rostering
         - kiegroup/optaweb-vehicle-routing
         - kiegroup/optaplanner-quickstarts

--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -29,6 +29,7 @@ dependencies:
           - source: (\d*)\.(.*)\.(.*)
             targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1+7}.${n2}.${n3}`)"
       exclude:
+        - kiegroup/drools
         - kiegroup/optaweb-employee-rostering
         - kiegroup/optaweb-vehicle-routing
         - kiegroup/optaplanner-quickstarts

--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -16,6 +16,23 @@ dependencies:
         - kiegroup/optaweb-vehicle-routing
         - kiegroup/optaplanner-quickstarts
 
+  - project: kiegroup/optaplanner
+    dependencies:
+      - project: kiegroup/drools
+    mapping:
+      dependencies:
+        default:
+          - source: (\d*)\.(.*)\.(.*)
+            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1-7}.${n2}.${n3}`)"
+      dependant:
+        default:
+          - source: (\d*)\.(.*)\.(.*)
+            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1+7}.${n2}.${n3}`)"
+      exclude:
+        - kiegroup/optaweb-employee-rostering
+        - kiegroup/optaweb-vehicle-routing
+        - kiegroup/optaplanner-quickstarts
+
   - project: kiegroup/kogito-runtimes
     dependencies:
       - project: kiegroup/drools
@@ -32,24 +49,6 @@ dependencies:
         - kiegroup/kogito-examples
         - kiegroup/kogito-apps
   
-  - project: kiegroup/optaplanner
-    dependencies:
-      - project: kiegroup/kogito-runtimes
-    mapping:
-      dependencies:
-        default:
-          - source: (\d*)\.(.*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1-7}.${n2}.${n3}`)"
-      dependant:
-        default:
-          - source: (\d*)\.(.*)\.(.*)
-            targetExpression: "process.env.GITHUB_BASE_REF.replace(/(\\d*)\\.(.*)\\.(.*)/g, (m, n1, n2, n3) => `${+n1+7}.${n2}.${n3}`)"
-      exclude:
-        - kiegroup/drools
-        - kiegroup/optaweb-employee-rostering
-        - kiegroup/optaweb-vehicle-routing
-        - kiegroup/optaplanner-quickstarts
-
   - project: kiegroup/kogito-apps
     dependencies:
       - project: kiegroup/kogito-runtimes


### PR DESCRIPTION
@radtriste As we discussed. Please double-check that this is correct.

Downstream PRs: 

* https://github.com/kiegroup/kogito-runtimes/pull/1929
* https://github.com/kiegroup/optaplanner/pull/1800

The changes have been tested against the downstream repos and all PR checks were green.
I checked the execution plans, and they did what they were supposed to.