### PR TITLE
Rename kogito-tooling to kie-tools

### DIFF
--- a/dsl/seed/config/branch.yaml
+++ b/dsl/seed/config/branch.yaml
@@ -22,7 +22,7 @@ repositories:
   - name: kogito-examples
   - name: kogito-images
   - name: kogito-operator
-  - name: kogito-tooling
+  - name: kie-tools
 
 # Full Example
 # repositories:


### PR DESCRIPTION
This change is needed due to:
- https://github.com/kiegroup/kie-tools/pull/791