### PR TITLE
[1.16.x] Update Jenkins CI to 3.8.1

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -5,7 +5,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem24g && !master'
     }
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
     parameters {

--- a/.ci/jenkins/Jenkinsfile.tools.update-dependency-version
+++ b/.ci/jenkins/Jenkinsfile.tools.update-dependency-version
@@ -8,7 +8,7 @@ pipeline {
     }
     
     tools {
-        maven 'kie-maven-3.6.3'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-5531

This is to harmonize all Jenkins CIs.
PR checks are already using the Maven 3.8.x

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/375
- https://github.com/kiegroup/drools/pull/4169
- https://github.com/kiegroup/kogito-runtimes/pull/1954
- https://github.com/kiegroup/optaplanner/pull/1814
- https://github.com/kiegroup/kogito-apps/pull/1220
- https://github.com/kiegroup/kogito-examples/pull/1105