### PR TITLE
[1.11.x] Fix the Jenkins buildchain

### DIFF
--- a/.ci/jenkins/Jenkinsfile.buildchain
+++ b/.ci/jenkins/Jenkinsfile.buildchain
@@ -44,7 +44,11 @@ pipeline {
 
                     configFileProvider([configFile(fileId: getSettingsXmlId(), variable: 'MAVEN_SETTINGS_FILE')]) {
                         withCredentials([string(credentialsId: 'kie-ci1-token', variable: 'GITHUB_TOKEN')]) {
+                            sh "build-chain-action -token=${GITHUB_TOKEN} -df='https://raw.githubusercontent.com/\${GROUP}/kogito-pipelines/1.11.x/.ci/${buildChainActionInfo.file}' -folder='bc' build ${buildChainActionInfo.action} -url=${env.ghprbPullLink} ${buildChainActionInfo.arguments} --skipParallelCheckout -cct '(^mvn .*)||\$1 -s ${MAVEN_SETTINGS_FILE} -Dmaven.wagon.http.ssl.insecure=true'"
                         }
+                    }
+                }
+            }
             post {
                 always {
                     junit '**/target/surefire-reports/**/*.xml, **/target/failsafe-reports/**/*.xml'


### PR DESCRIPTION
The Jenkins build chain, probably due to improper git conflict resolution in the past, has been broken on the `1.11.x` branch.