### PR TITLE
fix: resolve symlinks

### DIFF
--- a/tools/update-quarkus-versions.sh
+++ b/tools/update-quarkus-versions.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
-script_dir_path=`dirname "${BASH_SOURCE[0]}"`
+script_dir_path=$(cd `dirname "${BASH_SOURCE[0]}"`; pwd -P)
  
 GITHUB_URL="https://github.com/"
 GITHUB_URL_SSH="git@github.com:"


### PR DESCRIPTION
`dirname "${BASH_SOURCE[0]}"` may resolve to `.` making it a relative link which won't work if you are not in the root script dir.

alternatively, this uses `pwd -P` to resolve the symlink

      script_dir_path=$(cd `dirname "${BASH_SOURCE[0]}"`; pwd -P)