### PR TITLE
Added 1.13.x which will be used as product branch

### DIFF
--- a/dsl/seed/config/main.yaml
+++ b/dsl/seed/config/main.yaml
@@ -2,8 +2,7 @@ git:
   branches:
   - main
   - 1.11.x
-  - 1.16.x
-  - 1.17.x
+  - 1.13.x
   - 1.18.x
   main_branch:
     default: main


### PR DESCRIPTION
Depends on https://github.com/kiegroup/kogito-pipelines/pull/388

I backported changes from `main` which are useful and removed drools references.

- https://github.com/kiegroup/kogito-pipelines/pull/388
- https://github.com/kiegroup/kogito-pipelines/pull/390
- https://github.com/kiegroup/kogito-runtimes/pull/2028
- https://github.com/kiegroup/optaplanner/pull/1850
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/662
- https://github.com/kiegroup/optaweb-employee-rostering/pull/771
- https://github.com/kiegroup/optaplanner-quickstarts/pull/295
- https://github.com/kiegroup/kogito-apps/pull/1258
- https://github.com/kiegroup/kogito-examples/pull/1144
- https://github.com/kiegroup/kogito-images/pull/1126
- https://github.com/kiegroup/kogito-operator/pull/1139