### PR TITLE
Revert "Disable temporarily cloud nightly (#396)"

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -96,9 +96,9 @@ void setupNightlyJob() {
             booleanParam('SKIP_TESTS', false, 'Skip all tests')
 
             booleanParam('SKIP_ARTIFACTS', false, 'To skip Artifacts (runtimes, examples, optaplanner) Deployment')
-            booleanParam('SKIP_IMAGES', true, 'To skip Images Deployment')
-            booleanParam('SKIP_EXAMPLES_IMAGES', true, 'To skip Examples Images Deployment')
-            booleanParam('SKIP_OPERATOR', true, 'To skip Operator Deployment')
+            booleanParam('SKIP_IMAGES', false, 'To skip Images Deployment')
+            booleanParam('SKIP_EXAMPLES_IMAGES', false, 'To skip Examples Images Deployment')
+            booleanParam('SKIP_OPERATOR', false, 'To skip Operator Deployment')
 
             booleanParam('USE_TEMP_OPENSHIFT_REGISTRY', false, 'If enabled, use Openshift registry to push temporary images')
         }


### PR DESCRIPTION
This reverts commit 01404c9c37857990b88cd5d3b665856ed2f6dec0.

Enable back Cloud.

Should be merged once https://github.com/kiegroup/kogito-operator/pull/1153 is merged