### PR TITLE
[1.21.x] Bump quarkus version to 2.9.0.CR1

### DIFF
--- a/.ci/project-dependencies-quarkus.yaml
+++ b/.ci/project-dependencies-quarkus.yaml
@@ -6,7 +6,7 @@ dependencies:
       dependant:
         default:
           - source: .*
-            target: 2.8 # <quarkus-branch> quarkus placeholder for updating version - do not remove
+            target: 2.9 # <quarkus-branch> quarkus placeholder for updating version - do not remove
 
   - project: kiegroup/drools
     mapping:

--- a/dsl/seed/config/branch.yaml
+++ b/dsl/seed/config/branch.yaml
@@ -1,6 +1,6 @@
 lts:
   enabled: true
-  quarkus_version: '2.8'
+  quarkus_version: '2.9'
   native_builder_image: quay.io/quarkus/ubi-quarkus-mandrel:21.3-java11
 disable:
   triggers: false


### PR DESCRIPTION
cherry-pick: https://github.com/kiegroup/kogito-pipelines/pull/432

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/437
- https://github.com/kiegroup/drools/pull/4357
- https://github.com/kiegroup/kogito-runtimes/pull/2188
- https://github.com/kiegroup/optaplanner/pull/1967
- https://github.com/kiegroup/optaplanner-quickstarts/pull/330
- https://github.com/kiegroup/kogito-apps/pull/1331
- https://github.com/kiegroup/kogito-examples/pull/1245