### PR TITLE
KOGITO-7356 Do not use master node in pipelines

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -174,8 +174,8 @@ def getMessageBody(String propertiesFileUrl, String alreadyBuiltProjects) {
     def alreadyBuiltProjectsArray = (alreadyBuiltProjects ?: '').split(";")
     return """
 {
-	"propertiesFileUrl": "${propertiesFileUrl}",
-	"builtProjects": ${new groovy.json.JsonBuilder(alreadyBuiltProjectsArray).toString()}
+    "propertiesFileUrl": "${propertiesFileUrl}",
+    "builtProjects": ${new groovy.json.JsonBuilder(alreadyBuiltProjectsArray).toString()}
 }"""    
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7356

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/483
- https://github.com/kiegroup/kogito-runtimes/pull/2250
- https://github.com/kiegroup/kogito-apps/pull/1373
- https://github.com/kiegroup/kogito-examples/pull/1283
- https://github.com/kiegroup/optaplanner/pull/2021
- https://github.com/kiegroup/kogito-images/pull/1273
- https://github.com/kiegroup/kogito-operator/pull/1202
- https://github.com/kiegroup/kie-tools/pull/1021