### PR TITLE
[KOGITO-7504] Update Maven to 3.8.6

### DIFF
--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
   maven-version:
     description: "the maven version"
-    default: "3.8.1"
+    default: "3.8.6"
     required: false
   cache-key-prefix:
     description: "the cache key"

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -5,7 +5,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem24g && !master'
     }
     tools {
-        maven 'kie-maven-3.8.1'
+        maven 'kie-maven-3.8.6'
         jdk 'kie-jdk11'
     }
     parameters {

--- a/dsl/config/branch.yaml
+++ b/dsl/config/branch.yaml
@@ -61,4 +61,4 @@ jenkins:
   email_creds_id: KOGITO_CI_EMAIL_TO
   default_tools:
     jdk: kie-jdk11
-    maven: kie-maven-3.8.1
+    maven: kie-maven-3.8.6

--- a/kogito-cloud-operator-jenkins-slave/modules/maven-installer/3.8.x/install.sh
+++ b/kogito-cloud-operator-jenkins-slave/modules/maven-installer/3.8.x/install.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 set -e
-tar -C /usr/local/ -xf  /tmp/artifacts/apache-maven-3.8.1-bin.tar.gz
+tar -C /usr/local/ -xf  /tmp/artifacts/apache-maven-3.8.6-bin.tar.gz

--- a/kogito-cloud-operator-jenkins-slave/modules/maven-installer/3.8.x/module.yaml
+++ b/kogito-cloud-operator-jenkins-slave/modules/maven-installer/3.8.x/module.yaml
@@ -1,16 +1,16 @@
 name: org.kie.kogito.maven
-version: "3.8.1"
-description: "Module used to install maven 3.8.1"
+version: "3.8.6"
+description: "Module used to install maven 3.8.6"
 envs:
   - name: "MAVEN_VERSION"
-    value: "3.8.1"
+    value: "3.8.6"
   - name: "MAVEN_HOME"
-    value: "/usr/local/apache-maven-3.8.1/"
+    value: "/usr/local/apache-maven-3.8.6/"
   - name: PATH
-    value: /usr/local/apache-maven-3.8.1/bin/:$PATH
+    value: /usr/local/apache-maven-3.8.6/bin/:$PATH
 artifacts:
-  - name: apache-maven-3.8.1-bin.tar.gz
-    url: http://apachemirror.wuchna.com/maven/maven-3/3.8.1/binaries/apache-maven-3.8.1-bin.tar.gz
+  - name: apache-maven-3.8.6-bin.tar.gz
+    url: http://apachemirror.wuchna.com/maven/maven-3/3.8.6/binaries/apache-maven-3.8.6-bin.tar.gz
     sha512: c35a1803a6e70a126e80b2b3ae33eed961f83ed74d18fcd16909b2d44d7dada3203f1ffe726c17ef8dcca2dcaa9fca676987befeadc9b9f759967a8cb77181c0
 execute:
   - script: install.sh

--- a/kogito-operator-jenkins-node/image.yaml
+++ b/kogito-operator-jenkins-node/image.yaml
@@ -27,7 +27,7 @@ modules:
     - name: org.kie.kogito.graalvm
       version: "21.1.0-java-11"
     - name: org.kie.kogito.maven 
-      version: "3.8.1"
+      version: "3.8.6"
     - name: org.kie.kogito.podman
     - name: org.kie.kogito.jenkins-user
     - name: org.kie.kogito.cekit


### PR DESCRIPTION
Due to Quarkus future update

Related PRs:
- https://github.com/kiegroup/kogito-pipelines/pull/543
- https://github.com/kiegroup/kogito-runtimes/pull/2317
- https://github.com/kiegroup/kogito-apps/pull/1407
- https://github.com/kiegroup/kogito-examples/pull/1324
- https://github.com/kiegroup/drools/pull/4525
- https://github.com/kiegroup/optaplanner/pull/2063
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/728
- https://github.com/kiegroup/optaweb-employee-rostering/pull/841