### PR TITLE
[1.24.x][PROD Nightly] UMB message product version

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -46,7 +46,7 @@ pipeline {
                         {
                             def SETTINGS_XML_ID = '5d9884a1-178a-4d67-a3ac-9735d2df2cef'
                             def projectCollection = ['drools', 'kogito-runtimes', 'kogito-apps', 'kogito-examples']
-                            def projectVariableMap = [:]
+                            def projectVariableMap = ['kiegroup_kogito-runtimes': 'kogitoProductVersion']
                             def additionalVariables = [
                                 'droolsProductVersion': env.DROOLS_PRODUCT_VERSION, 
                                 'drools-scmRevision': getDroolsBranch(), 
@@ -97,7 +97,7 @@ pipeline {
                         def messageBody = getMessageBody(
                             mavenRepositoryFileUrl, 
                             env.ALREADY_BUILT_PROJECTS,
-                            ['serverlesslogic': PME_BUILD_VARIABLES['productVersion'], 'serverlesslogic-rhba': PME_BUILD_VARIABLES['productVersion']], 
+                            ['serverlesslogic': PME_BUILD_VARIABLES['kogitoProductVersion'], 'serverlesslogic-rhba': PME_BUILD_VARIABLES['kogitoProductVersion']], 
                             gitHashesToCollection(env.GIT_INFORMATION_HASHES)
                         )
                         echo "[INFO] Message Body: ${messageBody}"


### PR DESCRIPTION
The version was not stored after building the project due to the wrong configuration from `projectVariableMap` pmebuild attribute.
Now the version from UMB message will be something like `1.24.0.redhat-2022072511` instead `1.24.0`

Related PRs:

* https://github.com/kiegroup/kogito-pipelines/pull/569
* https://github.com/kiegroup/kogito-pipelines/pull/570