### PR TITLE
version.io.quarkus.quarkus-test-maven to version.io.quarkus.quarkus-test

### DIFF
--- a/.ci/pull-request-config-quarkus.yaml
+++ b/.ci/pull-request-config-quarkus.yaml
@@ -33,10 +33,10 @@ build:
     build-command:
       current: |
         mvn -f kogito-runtimes/pom.xml versions:compare-dependencies -pl :kogito-dependencies-bom -pl :kogito-build-parent -pl :kogito-quarkus-bom -pl :kogito-build-no-bom-parent -DremotePom=io.quarkus:quarkus-bom:999-SNAPSHOT -DupdatePropertyVersions=true -DupdateDependencies=true -DgenerateBackupPoms=false
-        mvn -f kogito-runtimes/pom.xml clean install -Dversion.io.quarkus.quarkus-test-maven=999-SNAPSHOT ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
+        mvn -f kogito-runtimes/pom.xml clean install -Dversion.io.quarkus.quarkus-test=999-SNAPSHOT ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
       upstream: |
         mvn versions:compare-dependencies -pl :kogito-dependencies-bom -pl :kogito-build-parent -pl :kogito-quarkus-bom -pl :kogito-build-no-bom-parent -DremotePom=io.quarkus:quarkus-bom:999-SNAPSHOT -DupdatePropertyVersions=true -DupdateDependencies=true -DgenerateBackupPoms=false
-        mvn clean install -Dquickly -Dversion.io.quarkus.quarkus-test-maven=999-SNAPSHOT ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn clean install -Dquickly -Dversion.io.quarkus.quarkus-test=999-SNAPSHOT ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
     clone:
       - kogito-runtimes
 

--- a/tools/update-quarkus-versions.sh
+++ b/tools/update-quarkus-versions.sh
@@ -84,7 +84,7 @@ case $REPO in
         MODULES[1]=kogito-build-parent
         MODULES[2]=kogito-quarkus-bom
         QUARKUS_PROPERTIES[0]=version.io.quarkus
-        QUARKUS_PROPERTIES[1]=version.io.quarkus.quarkus-test-maven
+        QUARKUS_PROPERTIES[1]=version.io.quarkus.quarkus-test
         ;;
     optaplanner)
         MODULES[0]=optaplanner-build-parent


### PR DESCRIPTION
Related to:

* https://github.com/kiegroup/kogito-runtimes/pull/2389
* https://github.com/kiegroup/kogito-pipelines/pull/583
* https://gitlab.cee.redhat.com/middleware/build-configurations/-/merge_requests/887