### PR TITLE
KOGITO-7076 Setup maven settings in composite action

### DIFF
--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -12,6 +12,10 @@ inputs:
   cache-key-prefix:
     description: "the cache key"
     required: false
+  allow-snapshots:
+    description: "the cache key"
+    required: false
+    default: "false"
 
 runs:
   using: "composite"
@@ -32,3 +36,72 @@ runs:
         path:  ~/.m2
         key: ${{ inputs.cache-key-prefix }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys:  ${{ inputs.cache-key-prefix }}-m2
+    - name: Setup Maven Settings
+      uses: whelk-io/maven-settings-xml-action@v20
+      with:
+        repositories: >
+          [
+            {
+              "id": "jboss-public-repository-group",
+              "name": "JBoss Public Repository Group",
+              "url": "https://repository.jboss.org/nexus/content/groups/public",
+              "releases": {
+                "enabled": "true",
+                "updatePolicy": "never"
+              },
+              "snapshots": {
+                "enabled": "${{ inputs.allow-snapshots }}",
+                "updatePolicy": "never"
+              }
+            },
+            {
+              "id": "kogito-staging-repository-group",
+              "name": "Kogito Staging Repositories",
+              "url": "https://repository.jboss.org/nexus/content/groups/kogito-public",
+              "releases": {
+                "enabled": "true",
+                "updatePolicy": "never"
+              },
+              "snapshots": {
+                "enabled": "${{ inputs.allow-snapshots }}",
+                "updatePolicy": "never"
+              }
+            }
+          ]
+        plugin_repositories: >
+          [
+            {
+              "id": "jboss-public-repository-group",
+              "name": "JBoss Public Repository Group",
+              "url": "https://repository.jboss.org/nexus/content/groups/public",
+              "releases": {
+                "enabled": "true",
+                "updatePolicy": "never"
+              },
+              "snapshots": {
+                "enabled": "${{ inputs.allow-snapshots }}",
+                "updatePolicy": "never"
+              }
+            },
+            {
+              "id": "kogito-staging-repository-group",
+              "name": "Kogito Staging Repositories",
+              "url": "https://repository.jboss.org/nexus/content/groups/kogito-public",
+              "releases": {
+                "enabled": "true",
+                "updatePolicy": "never"
+              },
+              "snapshots": {
+                "enabled": "${{ inputs.allow-snapshots }}",
+                "updatePolicy": "never"
+              }
+            }
+          ]
+        plugin_groups: >
+          [
+            "org.zanata"
+          ]
+    - name: Debug settings.xml
+      shell: bash
+      run: |
+        cat ~/.m2/settings.xml

--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -13,7 +13,11 @@ inputs:
     description: "the cache key"
     required: false
   allow-snapshots:
-    description: "the cache key"
+    description: "Whether the download of snapshots should be allowed"
+    required: false
+    default: "false"
+  debug:
+    description: "Activate debug display"
     required: false
     default: "false"
 
@@ -37,7 +41,7 @@ runs:
         key: ${{ inputs.cache-key-prefix }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys:  ${{ inputs.cache-key-prefix }}-m2
     - name: Setup Maven Settings
-      uses: whelk-io/maven-settings-xml-action@v20
+      uses: whelk-io/maven-settings-xml-action@v21
       with:
         repositories: >
           [
@@ -102,6 +106,7 @@ runs:
             "org.zanata"
           ]
     - name: Debug settings.xml
+      if: ${{ inputs.debug }}
       shell: bash
       run: |
         cat ~/.m2/settings.xml


### PR DESCRIPTION
We need to make sure that the `kiegroup` snapshot artifacts are not downloaded from Nexus to avoid any compatibility issue ...
This is already the case on Jenkins, thus we are sometimes having differences in behavior ...
At least now, the `settings.xml` file will be similar for PRs.