### PR TITLE
KOGITO-7906 Setup Mandrel LTS checks

### DIFF
--- a/dsl/config/branch.yaml
+++ b/dsl/config/branch.yaml
@@ -13,6 +13,8 @@ environment:
   mandrel:
     enabled: true
     builder_image: quay.io/quarkus/ubi-quarkus-mandrel:22.2-java11
+  mandrel_lts:
+    enabled: true
   runtimes_bdd:
     enabled: true
 productized_branch: true

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobUtils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobUtils.groovy
@@ -193,6 +193,10 @@ class KogitoJobUtils {
         return createPerEnvPerRepoPRJobs(script, [ Environment.MANDREL ], jobsRepoConfigGetter, defaultParamsGetter)
     }
 
+    static def createMandrelLTSPerRepoPRJobs(def script, Closure jobsRepoConfigGetter, Closure defaultParamsGetter = null) {
+        return createPerEnvPerRepoPRJobs(script, [ Environment.MANDREL_LTS ], jobsRepoConfigGetter, defaultParamsGetter)
+    }
+
     static def createQuarkusMainPerRepoPRJobs(def script, Closure jobsRepoConfigGetter, Closure defaultParamsGetter = null) {
         return createPerEnvPerRepoPRJobs(script, [ Environment.QUARKUS_MAIN ], jobsRepoConfigGetter, defaultParamsGetter)
     }

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
@@ -58,6 +58,10 @@ class Utils {
         return getBindingValue(script, 'ENVIRONMENT_MANDREL_ENABLED').toBoolean()
     }
 
+    static boolean isEnvironmentMandrelLTSEnabled(def script) {
+        return getBindingValue(script, 'ENVIRONMENT_MANDREL_LTS_ENABLED').toBoolean()
+    }
+
     static String getEnvironmentMandrelBuilderImage(def script) {
         return getBindingValue(script, 'ENVIRONMENT_MANDREL_BUILDER_IMAGE')
     }

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/model/Environment.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/model/Environment.groovy
@@ -79,6 +79,22 @@ class Environment {
         }
     )
 
+    public static final Environment MANDREL_LTS = new Environment(
+        name: 'MANDREL_LTS',
+        optional: true,
+        isActiveClosure: { script -> Utils.isEnvironmentMandrelLTSEnabled(script) },
+        getDefaultEnvVarsClosure: { script ->
+            [
+                NATIVE: 'true',
+                NATIVE_BUILDER_IMAGE: Utils.getEnvironmentMandrelBuilderImage(script),
+                ADDITIONAL_TIMEOUT: 720,
+                QUARKUS_BRANCH: Utils.getEnvironmentQuarkusLTSVersion(script),
+                BUILD_MVN_OPTS: '-Dproductized -Ddata-index-ephemeral.image=quay.io/kiegroup/kogito-data-index-ephemeral',
+                DISABLE_PERSISTENCE: 'true',
+            ]
+        }
+    )
+
     public static final Environment QUARKUS_MAIN = new Environment(
         name: 'QUARKUS_MAIN',
         optional: true,

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/model/Environment.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/model/Environment.groovy
@@ -139,6 +139,7 @@ class Environment {
         SONARCLOUD,
         NATIVE,
         MANDREL,
+        MANDREL_LTS,
         QUARKUS_MAIN,
         QUARKUS_BRANCH,
         QUARKUS_LTS,

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/model/Folder.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/model/Folder.groovy
@@ -120,6 +120,12 @@ class Folder {
         environment: Environment.MANDREL,
     )
 
+    public static final Folder NIGHTLY_MANDREL_LTS = new Folder(
+        name: 'NIGHTLY_MANDREL_LTS',
+        jobType: JobType.NIGHTLY,
+        environment: Environment.MANDREL_LTS,
+    )
+
     public static final Folder NIGHTLY_QUARKUS_MAIN = new Folder(
         name: 'NIGHTLY_QUARKUS_MAIN',
         jobType: JobType.NIGHTLY,
@@ -164,6 +170,12 @@ class Folder {
         name: 'PULLREQUEST_MANDREL',
         jobType: JobType.PULLREQUEST,
         environment: Environment.MANDREL,
+    )
+
+    public static final Folder PULLREQUEST_MANDREL_LTS = new Folder(
+        name: 'PULLREQUEST_MANDREL_LTS',
+        jobType: JobType.PULLREQUEST,
+        environment: Environment.MANDREL_LTS,
     )
 
     public static final Folder PULLREQUEST_QUARKUS_MAIN = new Folder(

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/model/Folder.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/model/Folder.groovy
@@ -67,6 +67,10 @@ class Folder {
         return this.environment == Environment.MANDREL
     }
 
+    boolean isMandrelLTS() {
+        return this.environment == Environment.MANDREL_LTS
+    }
+
     boolean isQuarkusMain() {
         return this.environment == Environment.QUARKUS_MAIN
     }
@@ -230,12 +234,14 @@ class Folder {
         NIGHTLY_SONARCLOUD,
         NIGHTLY_NATIVE,
         NIGHTLY_MANDREL,
+        NIGHTLY_MANDREL_LTS,
         NIGHTLY_QUARKUS_MAIN,
         NIGHTLY_QUARKUS_BRANCH,
         NIGHTLY_QUARKUS_LTS,
         PULLREQUEST,
         PULLREQUEST_NATIVE,
         PULLREQUEST_MANDREL,
+        PULLREQUEST_MANDREL_LTS,
         PULLREQUEST_QUARKUS_MAIN,
         PULLREQUEST_QUARKUS_BRANCH,
         PULLREQUEST_QUARKUS_LTS,


### PR DESCRIPTION
https://issues.redhat.com/browse/KOGITO-7906

This will add an environment to test against native Mandrel / Quarkus LTS version (which would be the productized behavior)

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/607
- https://github.com/kiegroup/drools/pull/4683
- https://github.com/kiegroup/kogito-runtimes/pull/2461
- https://github.com/kiegroup/kogito-apps/pull/1459
- https://github.com/kiegroup/kogito-examples/pull/1399