### PR TITLE
Revert "Remove `dependency:tree` from quarkus check"

### DIFF
--- a/.ci/pull-request-config-quarkus.yaml
+++ b/.ci/pull-request-config-quarkus.yaml
@@ -5,7 +5,7 @@ dependencies: ./project-dependencies-quarkus.yaml
 pre: |
   export BUILD_MVN_OPTS="${{ env.BUILD_MVN_OPTS }} -nsu -ntp -fae -e -Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=120 -Dmaven.wagon.http.retryHandler.count=3"
   echo "BUILD_MVN_OPTS=${{ env.BUILD_MVN_OPTS }}"
-  export BUILD_MVN_OPTS_CURRENT="${{ env.BUILD_MVN_OPTS_CURRENT }}"
+  export BUILD_MVN_OPTS_CURRENT="${{ env.BUILD_MVN_OPTS_CURRENT }} dependency:tree"
   echo "BUILD_MVN_OPTS_CURRENT=${{ env.BUILD_MVN_OPTS_CURRENT }}"
 
 default:


### PR DESCRIPTION
Reverts kiegroup/kogito-pipelines#648 as it was not the problem ...