### PR TITLE
[main] removed jcenter

### DIFF
--- a/dsl/seed/build.gradle
+++ b/dsl/seed/build.gradle
@@ -13,7 +13,6 @@ sourceSets {
 
 repositories {
     mavenCentral()
-    jcenter()
     maven {
         url 'https://repo.jenkins-ci.org/public/'
     }


### PR DESCRIPTION
more info details in Jfrog blog https://jfrog.com/blog/into-the-sunset-bintray-jcenter-gocenter-and-chartcenter/ why they shutdown the jcenter.bintray.com service