### PR TITLE
[BXMSPROD-1865] Add platform.quarkus.bom in nightly UMB message

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -97,7 +97,7 @@ pipeline {
                         def messageBody = getMessageBody(
                             mavenRepositoryFileUrl, 
                             env.ALREADY_BUILT_PROJECTS,
-                            ['serverlesslogic': PME_BUILD_VARIABLES['kogitoProductVersion'], 'serverlesslogic-rhba': PME_BUILD_VARIABLES['kogitoProductVersion'], 'drools': PME_BUILD_VARIABLES['droolsProductVersion']], 
+                            ['serverlesslogic': PME_BUILD_VARIABLES['kogitoProductVersion'], 'serverlesslogic-rhba': PME_BUILD_VARIABLES['kogitoProductVersion'], 'drools': PME_BUILD_VARIABLES['droolsProductVersion'], 'platform.quarkus.bom': PME_BUILD_VARIABLES['quarkusVersion'].replaceAll("\\{\\{.*\\}\\}", PME_BUILD_VARIABLES['quarkusVersionCommunity'])],
                             gitHashesToCollection(env.GIT_INFORMATION_HASHES)
                         )
                         echo "[INFO] Message Body: ${messageBody}"


### PR DESCRIPTION
**JIRA**
- https://issues.redhat.com/browse/BXMSPROD-1865

Added `platform.quarkus.bom` version information in UMB message. 
Value taken from PME build parameter: https://gitlab.cee.redhat.com/middleware/build-configurations/-/blob/master/openshift-serverless-logic/nightly/build-config.yaml#L8 .