### PR TITLE
BXMSPROD-1231 UMB message body with project version

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -1,5 +1,7 @@
 @Library('jenkins-pipeline-shared-libraries')_
 
+PME_EXECUTION_RESULT = [:]
+
 pipeline {
     agent {
         label 'kie-rhel7 && kie-mem24g && !built-in'
@@ -52,8 +54,9 @@ pipeline {
                                 'drools-scmRevision': getDroolsBranch(), 
                             ]
                             configFileProvider([configFile(fileId: '49737697-ebd6-4396-9c22-11f7714808eb', variable: 'PRODUCTION_PROJECT_LIST')]) {
-                                pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/openshift-serverless-logic/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
+                                PME_EXECUTION_RESULT = pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/openshift-serverless-logic/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
                             }
+                            println "[INFO] PME_EXECUTION_RESULT: ${PME_EXECUTION_RESULT}"
                         }, 2, 480*60)
                     }
                 }
@@ -62,7 +65,7 @@ pipeline {
         stage('Upload maven repository') {
             steps {
                 script {
-                    if(env.ALREADY_BUILT_PROJECTS?.trim()) {
+                    if(PME_EXECUTION_RESULT?.findAll{ it.value }) {
                         echo "[INFO] Start uploading ${env.WORKSPACE}/deployDirectory"
                         def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
                         if(fileExists("${env.WORKSPACE}/deployDirectory")){
@@ -87,7 +90,7 @@ pipeline {
         stage ('Send UMB Message to QE.') {
             steps {
                 script {
-                    if(env.ALREADY_BUILT_PROJECTS?.trim()) {
+                    if(PME_EXECUTION_RESULT) {
                         echo '[INFO] Sending OPENSHIFT SERVERLESS LOGIC UMB message to QE.'
                         def PME_BUILD_VARIABLES = env.PME_BUILD_VARIABLES.split(';').collect{ it.split('=')}.inject([:]) {map, item -> map << [(item.length == 2 ? item[0] : null): (item.length == 2 ? item[1] : null)]}
 
@@ -96,7 +99,7 @@ pipeline {
                         def eventType = "openshift-serverless-logic-${env.UMB_VERSION}-nightly-qe-trigger"
                         def messageBody = getMessageBody(
                             mavenRepositoryFileUrl, 
-                            env.ALREADY_BUILT_PROJECTS,
+                            PME_EXECUTION_RESULT,
                             ['serverlesslogic': PME_BUILD_VARIABLES['kogitoProductVersion'], 'serverlesslogic-rhba': PME_BUILD_VARIABLES['kogitoProductVersion'], 'drools': PME_BUILD_VARIABLES['droolsProductVersion'], 'platform.quarkus.bom': PME_BUILD_VARIABLES['quarkusVersion'].replaceAll("\\{\\{.*\\}\\}", PME_BUILD_VARIABLES['quarkusVersionCommunity'])],
                             gitHashesToCollection(env.GIT_INFORMATION_HASHES)
                         )
@@ -150,14 +153,13 @@ pipeline {
     }
 }
 
-def getMessageBody(String mavenRepositoryFileUrl, String alreadyBuiltProjects, Map<String, String> versions, Map<String, String> scmHashes) {
-    def alreadyBuiltProjectsArray = (alreadyBuiltProjects ?: '').split(";")
+def getMessageBody(String mavenRepositoryFileUrl, Map pmeExecutionResult, Map<String, String> versions, Map<String, String> scmHashes) {
     return """
 {
     "maven_repository_file_url": "${mavenRepositoryFileUrl}",
     "version": ${new groovy.json.JsonBuilder(versions).toString()},
     "scm_hash": ${new groovy.json.JsonBuilder(scmHashes).toString()},
-    "built_projects": ${new groovy.json.JsonBuilder(alreadyBuiltProjectsArray).toString()}
+    "built_projects": ${new groovy.json.JsonBuilder(pmeExecutionResult.collect{ it.key }).toString()}
 }"""    
 }
 


### PR DESCRIPTION
https://issues.redhat.com/browse/BXMSPROD-1231

- https://github.com/kiegroup/kogito-pipelines/pull/344
- https://github.com/kiegroup/jenkins-pipeline-shared-libraries/pull/180

@radtriste just consider to change the QE side consuming the UMB message
from `builtProjects: ['projectA', 'projectB']` to `builtProjects: {'projectA': 'versionX', 'projectB': 'versionY'}` 