### PR TITLE
[1.30.x] [BXMSPROD-1865] Added platform.quarkus.bom in nightly UMB message

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -97,7 +97,7 @@ pipeline {
                         def messageBody = getMessageBody(
                             mavenRepositoryFileUrl, 
                             env.ALREADY_BUILT_PROJECTS,
-                            ['serverlesslogic': PME_BUILD_VARIABLES['kogitoProductVersion'], 'serverlesslogic-rhba': PME_BUILD_VARIABLES['kogitoProductVersion'], 'drools': PME_BUILD_VARIABLES['droolsProductVersion']], 
+                            ['serverlesslogic': PME_BUILD_VARIABLES['kogitoProductVersion'], 'serverlesslogic-rhba': PME_BUILD_VARIABLES['kogitoProductVersion'], 'drools': PME_BUILD_VARIABLES['droolsProductVersion'], 'platform.quarkus.bom': PME_BUILD_VARIABLES['quarkusVersion'].replaceAll("\\{\\{.*\\}\\}", PME_BUILD_VARIABLES['quarkusVersionCommunity'])],
                             gitHashesToCollection(env.GIT_INFORMATION_HASHES)
                         )
                         echo "[INFO] Message Body: ${messageBody}"


### PR DESCRIPTION
**JIRA**
- https://issues.redhat.com/browse/BXMSPROD-1865

**Referenced Pull Requests**:
- Backport of https://github.com/kiegroup/kogito-pipelines/pull/675

Added `platform.quarkus.bom` version information in UMB message. 