### PR TITLE
Revert "[1.13.x] Bump Quarkus version to 2.13.4.Final"

### DIFF
--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -7,7 +7,7 @@ inputs:
     required: false
   maven-version:
     description: "the maven version"
-    default: "3.8.6"
+    default: "3.8.1"
     required: false
   cache-key-prefix:
     description: "the cache key"

--- a/.ci/jenkins/Jenkinsfile.buildchain
+++ b/.ci/jenkins/Jenkinsfile.buildchain
@@ -3,7 +3,7 @@
 agentLabel = "${env.ADDITIONAL_LABEL?.trim() ? ADDITIONAL_LABEL : 'kie-rhel7 && kie-mem16g'} && !built-in"
 timeoutValue = env.ADDITIONAL_TIMEOUT?.trim() ?: "180"
 jdkTool = env.BUILD_JDK_TOOL?.trim() ?: 'kie-jdk11'
-mavenTool = env.BUILD_MAVEN_TOOL?.trim() ?: 'kie-maven-3.8.6'
+mavenTool = env.BUILD_MAVEN_TOOL?.trim() ?: 'kie-maven-3.8.1'
 
 prType = env.BUILDCHAIN_PR_TYPE?.trim() ?: 'pr'
 settingsXmlId = isPR() || isFDB() ? 'kogito_pr_settings' : 'kogito_release_settings'

--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -5,7 +5,7 @@ pipeline {
         label 'kie-rhel7 && kie-mem24g && !built-in'
     }
     tools {
-        maven 'kie-maven-3.8.6'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
     parameters {
@@ -184,8 +184,8 @@ def getMessageBody(String propertiesFileUrl, String alreadyBuiltProjects) {
     def alreadyBuiltProjectsArray = (alreadyBuiltProjects ?: '').split(";")
     return """
 {
-    "propertiesFileUrl": "${propertiesFileUrl}",
-    "builtProjects": ${new groovy.json.JsonBuilder(alreadyBuiltProjectsArray).toString()}
+	"propertiesFileUrl": "${propertiesFileUrl}",
+	"builtProjects": ${new groovy.json.JsonBuilder(alreadyBuiltProjectsArray).toString()}
 }"""    
 }
 

--- a/.ci/jenkins/Jenkinsfile.tools.update-dependency-version
+++ b/.ci/jenkins/Jenkinsfile.tools.update-dependency-version
@@ -8,7 +8,7 @@ pipeline {
     }
     
     tools {
-        maven 'kie-maven-3.8.6'
+        maven 'kie-maven-3.8.1'
         jdk 'kie-jdk11'
     }
 

--- a/kogito-operator-jenkins-node/image.yaml
+++ b/kogito-operator-jenkins-node/image.yaml
@@ -27,7 +27,7 @@ modules:
     - name: org.kie.kogito.graalvm
       version: "21.1.0-java-11"
     - name: org.kie.kogito.maven 
-      version: "3.8.6"
+      version: "3.8.1"
     - name: org.kie.kogito.podman
     - name: org.kie.kogito.jenkins-user
     - name: org.kie.kogito.cekit


### PR DESCRIPTION
Reverts kiegroup/kogito-pipelines#689

Related:
- https://github.com/kiegroup/kogito-pipelines/pull/715
- https://github.com/kiegroup/kogito-runtimes/pull/2628
- https://github.com/kiegroup/kogito-apps/pull/1514
- https://github.com/kiegroup/kogito-examples/pull/1483
- https://github.com/kiegroup/optaplanner/pull/2332
- https://github.com/kiegroup/optaplanner-quickstarts/pull/458