### PR TITLE
new pipeline job for tagging/bumping up kie-docs

### DIFF
--- a/.ci/jenkins/Jenkinsfile.ecosystem.update-kogito-docs
+++ b/.ci/jenkins/Jenkinsfile.ecosystem.update-kogito-docs
@@ -1,0 +1,217 @@
+import org.jenkinsci.plugins.workflow.libs.Library
+@Library('jenkins-pipeline-shared-libraries')_
+
+import org.kie.jenkins.MavenCommand
+
+AGENT_LABEL = "kie-rhel7-priority && !built-in"
+kogitoDocsRepo = "kie-docs"
+prBranchPrefix = "bump-up-kogito-docs"
+COMMIT_MSG = "bumped up versions"
+KOGITO_DOCS_BRANCH = "main-kogito"
+PR_BODY="Please review and merge"
+
+pipeline {
+
+    agent {
+        label "${AGENT_LABEL}"
+    }
+
+    options{
+        timestamps()
+        timeout(time: 60, unit: 'MINUTES')
+    }
+
+    tools {
+        maven "${BUILD_MAVEN_TOOL}"
+        jdk "${BUILD_JDK_TOOL}"
+    }
+
+    environment {
+        // Static env is defined into .jenkins/dsl/jobs.groovy file
+        KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+        PR_BRANCH = "${prBranchPrefix}-${util.generateHash(10)}"
+    }
+
+    stages{
+        stage('CleanWorkspace') {
+            steps {
+                cleanWs()
+            }
+        }
+        stage('Initialize') {
+            steps{
+                script{
+                    sh 'printenv'
+                    dir(kogitoDocsRepo){
+                        checkoutRepo(kogitoDocsRepo, GIT_AUTHOR, KOGITO_DOCS_BRANCH, GIT_AUTHOR_CREDENTIALS_ID)
+                    }
+                }
+            }
+        }
+        stage('Create pull request branch') {
+            steps{
+                script{
+                    dir(kogitoDocsRepo){
+                        githubscm.createBranch(PR_BRANCH)
+
+                    }
+                }
+            }
+        }
+        stage('Update kogito-docs version') {
+            steps {
+                script {
+                    dir("${kogitoDocsRepo}/doc-content/kogito-docs") {
+                        maven.mvnVersionsSet(parseVersion(getVersion()))
+                        githubscm.commitChanges(COMMIT_MSG)
+                    }
+                }
+            }
+        }
+        stage('Build kogito-docs') {
+            steps {
+                configFileProvider([configFile(fileId: '771ff52a-a8b4-40e6-9b22-d54c7314aa1e', targetLocation: 'jenkins-settings.xml', variable: 'SETTINGS_XML_FILE')]) {
+                    dir("${kogitoDocsRepo}/doc-content/kogito-docs") {
+                    sh""" mvn clean install -Dfull -s $SETTINGS_XML_FILE -Dkie.maven.settings.custom=$SETTINGS_XML_FILE -Dmaven.test.redirectTestOutputToFile=true -Dmaven.test.failure.ignore=true
+                         # clean files created by the build
+                         git clean -d -f """
+                    }
+                }
+            }
+        }
+        stage('Create file for folder creation'){
+            steps{
+                script {
+                    dir("${kogitoDocsRepo}/doc-content/kogito-docs") {
+                        def data = "mkdir ${getVersion()}"
+                        writeFile(file: 'upload_version.txt', text: data)
+                        sh "chmod +x upload_version.txt"
+                    }
+                }
+            }
+        }
+        stage('Upload kogito-docs') {
+            steps {
+                sshagent(credentials: ['KogitoDocsUpload']) {
+                    script {
+                        dir("${kogitoDocsRepo}/doc-content/kogito-docs") {
+                            sftp -b upload_version.txt getSshPath()
+                            sh "rm upload_version.txt"
+                            // upload of the kogito-docs to filemgmt-prod-sync.jboss.org
+                            sh "rsync -Pavqr -e \"ssh -p 2222\" --protocol=28 --delete-after target/generated-docs/html_single ${getRsyncPath()}/${getVersion()}"
+                            // upload latest links
+                            sh "mkdir filemgmt_link"
+                            sh "cd filemgmt_link"
+                            sh "touch ${getVersion()}"
+                            sh "ln -s ${getVersion()} latest"
+                            sh "rsync -a -e \"ssh -p 2222\" --protocol=28 latest ${getRsyncPath()}"
+                            echo "symbolic links uploaded"
+                            sh "cd .."
+                            sh "unlink latest"
+                            sh "rm ${getVersion()}"
+                            sh "rm -rf filemgmt_link"
+                        }
+                    }
+                }
+            }
+        }
+        stage('Create and push tag') {
+            steps {
+                dir("${kogitoDocsRepo}/doc-content/kogito-docs") {
+                    script {
+                        githubscm.tagRepository("${getVersion()}-kogito")
+                        githubscm.pushRemoteTag('origin', "${getVersion()}-kogito")
+                    }
+                }
+            }
+        }
+        stage('Bump up kogito-docs to next SNAPSHOT'){
+            steps{
+                dir("${kogitoDocsRepo}/doc-content/kogito-docs") {
+                    script{
+                        maven.mvnVersionsSet(parseNextVersion(getVersion()))
+                    }
+                }
+            }
+        }
+        stage('Bump up kie version') {
+            when {
+                expression { return isNewVersionRequired() }
+            }
+            steps {
+                dir("${kogitoDocsRepo}") {
+                    script {
+                        // bump up if the current kie version is greater then the
+                        maven.mvnVersionsUpdateParentAndChildModules("${env.KIE_VERSION}", true)
+                    }
+                }
+            }
+        }
+        stage('Add and commit latest changes'){
+            steps{
+                dir("${kogitoDocsRepo}"){
+                    script{
+                        githubscm.commitChanges(COMMIT_MSG)
+                    }
+                }
+            }
+        }
+        stage('Create and push pullrequest'){
+            steps{
+                 dir("${kogitoDocsRepo}"){
+                     script {
+                        githubscm.pushObject('origin', PR_BRANCH)
+                        githubscm.createPR(COMMIT_MSG,PR_BODY,KOGITO_DOCS_BRANCH)
+                     }
+                 }
+            }
+        }
+    }
+    post {
+        unsuccessful {
+            sendErrorNotification()
+        }
+    }
+}
+
+void checkoutRepo(String repo, String GIT_AUTHOR, String branch, String GIT_AUTHOR_CREDENTIALS_ID){
+    checkout(githubscm.resolveRepository(repo, GIT_AUTHOR, branch, false, GIT_AUTHOR_CREDENTIALS_ID))
+    // need to manually checkout branch since on a detached branch after checkout command
+    sh "git checkout ${branch}"
+}
+
+String getVersion(){
+    return params.KOGITO_DOCS_VERSION
+}
+
+String getSshPath(){
+    return env.SSH_KOGITO_DOCS_PATH
+}
+
+String getRsyncPath(){
+    return env.RSYNC_KOGITO_DOCS_PATH
+}
+
+void sendNotification(String body){
+    emailext body: "${body}",
+             subject: "Update kogito-docs",
+             to: env.KOGITO_CI_EMAIL_TO
+}
+
+boolean isNewVersionRequired() {
+    return params.BUMP_UP
+}
+
+void sendErrorNotification(){
+    sendNotification("Job #${BUILD_NUMBER} was: **${currentBuild.currentResult}**\nPlease look here: ${BUILD_URL}")
+}
+
+String parseVersion(String docVersion){
+    Integer[] versionSplit = util.parseVersion(docVersion)
+    return "${versionSplit[0]}.${versionSplit[1]}.${versionSplit[2]}"
+}
+
+String parseNextVersion(String docVersion){
+    Integer[] versionSplit = util.parseVersion(docVersion)
+    return "${versionSplit[0]}.${versionSplit[1] + 1}.${versionSplit[2]}-SNAPSHOT"
+}

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -30,6 +30,7 @@ setupNightlyJob()
 
 // Release
 setupReleaseJob()
+setupDocsJob()
 
 /////////////////////////////////////////////////////////////////
 // Methods
@@ -200,4 +201,23 @@ void setupReleaseJob() {
 void setupBuildOperatorNode() {
     def jobParams = KogitoJobUtils.getBasicJobParams(this, 'build-operator-node', Folder.TOOLS, "${JENKINSFILE_PATH}/Jenkinsfile.build-operator-node")
     KogitoJobTemplate.createPipelineJob(this, jobParams)
+}
+
+void setupDocsJob() {
+    def jobParams = KogitoJobUtils.getBasicJobParams(this, 'kogito-docs', Folder.RELEASE, "${JENKINSFILE_PATH}/Jenkinsfile.ecosystem.update-kogito-docs", "Update Kogito docs")
+    KogitoJobUtils.setupJobParamsDefaultMavenConfiguration(this, jobParams)
+    jobParams.env.putAll([
+            JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
+            GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
+            GIT_AUTHOR_CREDENTIALS_ID: "${GIT_AUTHOR_CREDENTIALS_ID}",
+            SSH_KOGITO_DOCS_PATH: "${FILEMGMT_KOGITO_DOCS_SFTP_URL}",
+            RSYNC_KOGITO_DOCS_PATH: "${FILEMGMT_KOGITO_DOCS_RSYNC_URL}",
+    ])
+    KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
+        parameters {
+            stringParam('KOGITO_DOCS_VERSION', '', 'Kogito docs version to release as Major.minor.micro')
+            booleanParam('BUMP_UP',false,'Is a new KIE version needed?')
+            stringParam('KIE_VERSION','','KIE version to bump up to as Major.minor.micro-SNAPSHOT')
+        }
+    }
 }

--- a/dsl/config/branch.yaml
+++ b/dsl/config/branch.yaml
@@ -82,3 +82,6 @@ jenkins:
   default_tools:
     jdk: kie-jdk11
     maven: kie-maven-3.8.6
+filemgmt:
+  kogito_docs_sftp_url: kogito@filemgmt-prod.jboss.org:/docs_htdocs/kogito/release
+  kogito_docs_rsync_url: kogito@filemgmt-prod-sync.jboss.org:/docs_htdocs/kogito/release


### PR DESCRIPTION
this new job should replace https://eng-jenkins-csb-business-automation.apps.ocp-c1.prod.psi.redhat.com/job/KIE/job/kogito/job/kogito-docs/job/uploadKogitoDocs/

- this new job follows the current kogito pipeline methodology
- the job creates and pushes a tag for kogito docs: kie-docs/doc-content/kogito-docs /main-kogito branch)
- rsyncs the target/generated-docs/html_single to filemgmgt.jboss.org so the docs are visible here:  https://docs.kogito.kie.org/latest/html_single/ (btw. the version is still 1.28.0)
- there are only three parameters 
- KOGITO_DOCS_VERSION (version of new kogito-docs release)
- BUMP_UP (checkbox to select if t is needed to bump up the KIE version)
- KIE_VERSION (SNAPSHOT version of KIE in case the kie version in main-kogito docs is another than in kiegroup/XXX)
- this job should run when the kogito docs (kie-docs main-kogito branch)  is up to date and all PRs are merged
- this job has to be triggered manually