### PR TITLE
[BXMSPROD-1892] Automated pr backporting reusable actions

### DIFF
--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -1,0 +1,60 @@
+name: 'Pull Request Backporting'
+description: 'Creates a backporting pull request'
+
+inputs:
+  target-branch:
+    description: "The branch where the cherry-pick must be applied"
+    required: true
+  title:
+    description: "The cherry-pick pull request title"
+    default: "${{ github.event.pull_request.title }}"
+    required: false
+  body:
+    description: "The cherry-pick pull request body"
+    default: "${{ github.event.pull_request.body }}"
+    required: false
+  original-pr-url:
+    description: "Original pull request url"
+    default: "${{ github.event.pull_request.html_url }}"
+    required: false
+  original-pr-branch:
+    description: "Original pull request branch name"
+    default: "${{ github.event.pull_request.head.ref }}"
+    required: false
+  author:
+    description: "Author of the original pull request"
+    default: "${{ github.event.pull_request.user.login }}"
+    required: false
+  additional-reviewers:
+    description: "Additional backported pull request reviewers, e.g., toJSON(github.event.pull_request.requested_reviewers)"
+    default: "[]"
+    required: false
+
+runs: 
+  using: 'composite'
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+    - name: Prepare reviewers
+      id: prepare-reviewers
+      shell: bash
+      run: |
+        echo "Additional reviewers retrieved below"
+        echo "${{ inputs.additional-reviewers }}"
+        reviewers="$(echo ${{ inputs.additional-reviewers }} | jq -c 'map(.login)' | jq -cr '. |= . + ["${{ inputs.author }}"] | unique | join(",")')"
+        echo "reviewers = ${reviewers}"
+        echo "BACKPORT_REVIEWERS=${reviewers}" >> $GITHUB_ENV
+    - name: Perform cherry pick
+      id: cherry-pick
+      uses: carloscastrojumo/github-cherry-pick-action@v1.0.5
+      with:
+        branch: "${{ inputs.target-branch }}"
+        title: "[${{ inputs.target-branch }}] ${{ inputs.title }}"
+        body: "**Backport:** ${{ inputs.original-pr-url }}\r\n\r\n${{ inputs.body }}"
+        labels: |
+          cherry-pick :cherries:
+        inherit_labels: false
+        cherry-pick-branch: "${{ inputs.target-branch }}_${{ inputs.original-pr-branch }}"
+        reviewers: ${{ env.BACKPORT_REVIEWERS }}

--- a/.ci/actions/parse-labels/action.yml
+++ b/.ci/actions/parse-labels/action.yml
@@ -1,0 +1,40 @@
+name: 'Parse Labels'
+description: 'Extract target branches or refs from labels'
+
+inputs:
+  labels:
+    description: "List of label objects to be parsed, e.g., github.event.pull_request.labels"
+    required: true
+  label-prefix:
+    description: "Extract targets from labels matching this provided prefix"
+    default: "backport-"
+    required: false
+
+outputs:
+  targets:
+    description: "Extracted targets"
+    value: ${{ steps.extract-targets.outputs.targets }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Fetch labels
+      id: fetch-labels
+      shell: bash
+      run: |
+        echo "Labels retrieved below"
+        echo "${{ inputs.labels }}"
+        filtered_labels="$(echo ${{ inputs.labels }} | jq -c 'map(select(.name | startswith("${{ inputs.label-prefix }}")))')"
+        echo "filtered_labels = ${filtered_labels}"
+        echo "FILTERED_LABELS=${filtered_labels}" >> $GITHUB_ENV
+
+    - name: Extract targets
+      id: extract-targets
+      shell: bash
+      run: |
+        targets="$(echo $FILTERED_LABELS | jq -c '[.[] | .name | sub("${{ inputs.label-prefix }}"; "")]')"
+        echo "::set-output name=targets::$(echo $targets)" 
+    
+    - name: Printing extracted targets
+      shell: bash
+      run: echo "Extracted target branches ${{ steps.extract-targets.outputs.targets }}"

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -1,0 +1,43 @@
+name: Pull Request Backporting
+
+on:
+  pull_request_target:
+    types: [closed, labeled]
+    branches:
+      - main
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+jobs:
+  compute-targets:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged }}
+    runs-on: ubuntu-latest
+    outputs:
+      target-branches: ${{ steps.set-targets.outputs.targets }}
+    env:
+      LABELS: ${{ toJSON(github.event.pull_request.labels) }}
+    steps:
+      - name: Set target branches
+        id: set-targets
+        uses: kiegroup/kogito-pipelines/.ci/actions/parse-labels@main
+        with:
+          labels: ${LABELS}
+  
+  backporting:
+    if: ${{ github.event.pull_request.state == 'closed' && github.event.pull_request.merged && needs.compute-targets.outputs.target-branches != '[]' }}
+    name: "[${{ matrix.target-branch }}] - Backporting"
+    runs-on: ubuntu-latest
+    needs: compute-targets
+    strategy:
+      matrix: 
+        target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
+      fail-fast: true
+    env:
+      REVIEWERS: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
+    steps:
+      - name: Backporting
+        uses: kiegroup/kogito-pipelines/.ci/actions/backporting@main
+        with:
+          target-branch: ${{ matrix.target-branch }}
+          additional-reviewers: ${REVIEWERS}


### PR DESCRIPTION
**JIRA**: 

https://issues.redhat.com/browse/BXMSPROD-1892

**referenced Pull Requests**:

* https://github.com/carloscastrojumo/github-cherry-pick-action/pull/26
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2165

**Workflows PRs**:
- https://github.com/kiegroup/drools/pull/4863
- https://github.com/kiegroup/kogito-runtimes/pull/2684
- https://github.com/kiegroup/kogito-examples/pull/1504
- https://github.com/kiegroup/kogito-apps/pull/1558
- https://github.com/kiegroup/optaplanner/pull/2451
- https://github.com/kiegroup/optaweb-employee-rostering/pull/882
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/831
- https://github.com/kiegroup/optaplanner-quickstarts/pull/470
- https://github.com/kiegroup/optaplanner-website/pull/560
- https://github.com/kiegroup/drools-website/pull/236

**Improvements**:

Created two reusable actions:
- _backporting_: this action applies the cherry-pick and creates one or more pull requests in according to their inputs
- _parse-labels_: parse pull request labels extracting target branches
