### PR TITLE
[BXMSPROD-1936] Fix default reviewers and customization

### DIFF
--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -25,10 +25,21 @@ inputs:
     description: "Author of the original pull request"
     default: "${{ github.event.pull_request.user.login }}"
     required: false
-  additional-reviewers:
-    description: "Additional backported pull request reviewers, e.g., toJSON(github.event.pull_request.requested_reviewers)"
-    default: "[]"
+  include-merge-as-reviewer:
+    description: "Whether include or not who merged the pull request as reviewer of the backported one"
+    default: "true"
     required: false
+  include-requested-reviewers:
+    description: "Whether include or not original requested reviewers"
+    default: "true"
+    required: false
+  custom-reviewers:
+    description: "Comma separated list of additional reviewers to be added in backported pull request"
+    required: false
+  additional-reviewers:
+    description: "Additional backported pull request reviewers, default is toJSON(github.event.pull_request.requested_reviewers)"
+    required: false
+    deprecationMessage: "[IGNORED] The previous default is managed by `include-requested-reviewers`. If you want to add more custom reviewers use `custom-reviewers` input instead"
 
 runs: 
   using: 'composite'
@@ -37,18 +48,47 @@ runs:
       uses: actions/checkout@v3
       with:
         fetch-depth: 0
+    - name: Setup default values
+      shell: bash
+      env:
+        REQUESTED_REVIEWERS: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
+        MERGED_BY: ${{ github.event.pull_request.merged_by.login }}
+        CUSTOM_REVIEWERS: ""
+      run: |
+        # -- Additional Reviewers --
+        # trick to save multiline string as env variable
+        echo "REQUESTED_REVIEWERS<<EOF" >> $GITHUB_ENV
+        input_include_requested_revs=${{ inputs.include-requested-reviewers }}
+        [[ "$input_include_requested_revs" == "true" ]] && echo "$REQUESTED_REVIEWERS" >> $GITHUB_ENV || echo "[]" >> $GITHUB_ENV
+        echo "EOF" >> $GITHUB_ENV
+
+        # -- Custom Reviewers --
+        input_custom_revs=${{ inputs.custom-reviewers }}
+        [[ ! -z "$input_custom_revs" ]] \
+          && echo "CUSTOM_REVIEWERS=$(echo "[\"${input_custom_revs/,/\",\"}\"]")" >> $GITHUB_ENV \
+          || echo "CUSTOM_REVIEWERS=[]" >> $GITHUB_ENV
+
+        # -- Merged By Reviewer --
+        input_include_merge=${{ inputs.include-merge-as-reviewer }}
+        [[ "$input_include_merge" == "true" ]] && echo "MERGED_BY=$MERGED_BY" >> $GITHUB_ENV || echo "MERGED_BY=" >> $GITHUB_ENV
+
     - name: Prepare reviewers
       id: prepare-reviewers
       shell: bash
       run: |
-        echo "Additional reviewers retrieved below"
-        echo "${{ inputs.additional-reviewers }}"
-        reviewers="$(echo ${{ inputs.additional-reviewers }} | jq -c 'map(.login)' | jq -cr '. |= . + ["${{ inputs.author }}"] | unique | join(",")')"
+        env
+
+        # starts from request reviewers or empty array
+        reviewers="$(echo ${REQUESTED_REVIEWERS:-[]} | jq -c 'map(.login)' | jq -cr '[. |= . + ["${{ inputs.author }}", "${{ env.MERGED_BY }}"] | .[] | select(length > 0)] | unique')"
+
+        # add custom reviewers, if any
+        reviewers="$(jq -cr --argjson arr1 "$reviewers" --argjson arr2 "${CUSTOM_REVIEWERS:-[]}" -n '$arr1 + $arr2 | unique | join(",")')"
+
         echo "reviewers = ${reviewers}"
         echo "BACKPORT_REVIEWERS=${reviewers}" >> $GITHUB_ENV
     - name: Perform cherry pick
       id: cherry-pick
-      uses: carloscastrojumo/github-cherry-pick-action@v1.0.5
+      uses: carloscastrojumo/github-cherry-pick-action@v1.0.6
       with:
         branch: "${{ inputs.target-branch }}"
         title: "[${{ inputs.target-branch }}] ${{ inputs.title }}"

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -33,11 +33,8 @@ jobs:
       matrix: 
         target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
       fail-fast: true
-    env:
-      REVIEWERS: ${{ toJSON(github.event.pull_request.requested_reviewers) }}
     steps:
       - name: Backporting
         uses: kiegroup/kogito-pipelines/.ci/actions/backporting@main
         with:
           target-branch: ${{ matrix.target-branch }}
-          additional-reviewers: ${REVIEWERS}


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/BXMSPROD-1936

**referenced Pull Requests**:

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2175
* https://github.com/kiegroup/kogito-pipelines/pull/752

**Improvements**

Added new input parameters:
* `include-merge-as-reviewer`: whether to include or not the user who merged the PR as reviewer, default `true`
* `include-requested-reviewers`: whether to include original requested reviewers into backported pr, notice that approved reviewers are not in this list since ti seems github remove them. Default `true`
* `custom-reviewers`: allows users to customize the workflow adding additional custom reviewers

Deprecated `additional-reviewers` as it is now managed internally in the composite actions itself, this field will be ignored since now.

Thus we can remove that parameter from any workflow without changing the final result as `include-requested-reviewers` is set to true by default.