### PR TITLE
[BXMSPROD-1937] using env file instead of set-output

### DIFF
--- a/.ci/actions/os-preparation/action.yaml
+++ b/.ci/actions/os-preparation/action.yaml
@@ -38,7 +38,7 @@ runs:
           echo "No configuration found for [repo=$repo_name, event=$event, value=$label_name] at $GITHUB_WORKSPACE/$config_file"
           exit 1
         else 
-          echo "::set-output name=operating_systems::$(echo $os)" 
+          echo "operating_systems=$(echo $os)" >> $GITHUB_OUTPUT
         fi
     - name: Printing configured operating systems
       shell: bash

--- a/.ci/actions/parse-labels/action.yml
+++ b/.ci/actions/parse-labels/action.yml
@@ -33,7 +33,7 @@ runs:
       shell: bash
       run: |
         targets="$(echo $FILTERED_LABELS | jq -c '[.[] | .name | sub("${{ inputs.label-prefix }}"; "")]')"
-        echo "::set-output name=targets::$(echo $targets)" 
+        echo "targets=$(echo $targets)" >> $GITHUB_OUTPUT
     
     - name: Printing extracted targets
       shell: bash


### PR DESCRIPTION
**JIRA**: 

https://issues.redhat.com/browse/BXMSPROD-1937

**referenced Pull Requests**: 

* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2174
* https://github.com/kiegroup/kogito-pipelines/pull/754

Based on https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/ I changed from:
```
echo "::set-output name={name}::{value}"
```
to:
```
echo "{name}={value}" >> $GITHUB_OUTPUT
```