### PR TITLE
Remove JVM perm space settings

### DIFF
--- a/.ci/jenkins/Jenkinsfile.buildchain
+++ b/.ci/jenkins/Jenkinsfile.buildchain
@@ -53,7 +53,7 @@ pipeline {
     }
     environment {
         FIREFOX_FOLDER = '/opt/tools/firefox-60esr'
-        MAVEN_OPTS = '-Xms1024m -Xmx6g -XX:PermSize=128m -XX:MaxPermSize=512m'
+        MAVEN_OPTS = '-Xms1024m -Xmx6g'
     }
     stages {
         stage('Initialize') {


### PR DESCRIPTION
After upgrading JDK 17 for OptaPlanner pipelines, PR checks fail due to:

```
2023-02-01T14:13:01.222Z] Unrecognized VM option 'PermSize=128m'
[2023-02-01T14:13:01.222Z] Error: Could not create the Java Virtual Machine.
```

Perhaps it's time to finally remove these settings that have been long deprecated already.
