### PR TITLE
[BXMSPROD-728] include `commit` and `check_name`

### DIFF
--- a/.ci/actions/surefire-report/action.yml
+++ b/.ci/actions/surefire-report/action.yml
@@ -21,7 +21,7 @@ runs:
   using: "composite"
   steps: 
     - name: Check Surefire Report
-      uses: ScaCap/action-surefire-report@v1.0.13
+      uses: ScaCap/action-surefire-report@v1.1.0
       with:
         fail_on_test_failures: true
         fail_if_no_tests: false

--- a/.ci/actions/surefire-report/action.yml
+++ b/.ci/actions/surefire-report/action.yml
@@ -9,7 +9,14 @@ inputs:
     description: "Whether to publish test results as annotation or not"
     required: false
     default: "true"
-
+  check_name:
+    description: "Check name to use when creating a check run"
+    required: false
+    default: "Test Report"
+  commit:
+    description: "The commit sha to update the status"
+    required: false
+    
 runs:
   using: "composite"
   steps: 
@@ -20,6 +27,8 @@ runs:
         fail_if_no_tests: false
         skip_publishing: ${{ inputs.skip_publishing }}
         report_paths: ${{ inputs.report_paths }}
+        commit: ${{ inputs.commit }}
+        check_name: ${{ inputs.check_name }}
       env:
         # https://github.com/ScaCap/action-surefire-report/issues/17
         NODE_OPTIONS: '--max_old_space_size=4096'


### PR DESCRIPTION
Include `commit` and `check_name` to be passed as input to surefire action.
Note that it should be fine to have no default for `commit` because surefire action will automatically pick up the right sha if commit is undefined or an empty string:
https://github.com/ScaCap/action-surefire-report/blob/master/action.js#L36

Also updated surefire action to node16 version since node12 is deprecated

