### PR TITLE
DSL: Disable quarkus-main check

### DIFF
--- a/dsl/config/branch.yaml
+++ b/dsl/config/branch.yaml
@@ -16,6 +16,7 @@ environments:
     - native
     - prod
   quarkus-main:
+    enabled: false
     env_vars:
       QUARKUS_BRANCH: main
     ids:


### PR DESCRIPTION
Due to Quarkus 3 change.
To set back once Quarkus 3 work is stable