### PR TITLE
Build-chain: Allow to setup default quarkus version in env

### DIFF
--- a/.ci/jenkins/Jenkinsfile.buildchain
+++ b/.ci/jenkins/Jenkinsfile.buildchain
@@ -113,7 +113,9 @@ pipeline {
                             .run('clean install')
 
                         // Setup the quarkus version for the build-chain config
-                        env.QUARKUS_VERSION = '999-SNAPSHOT'
+                        if (!env.QUARKUS_VERSION) {
+                            env.QUARKUS_VERSION = '999-SNAPSHOT'
+                        }
                     }
                 }
             }

--- a/dsl/config/branch.yaml
+++ b/dsl/config/branch.yaml
@@ -24,6 +24,8 @@ environments:
   quarkus-branch:
     env_vars:
       QUARKUS_BRANCH: '2.16'
+      # Due to https://github.com/quarkusio/quarkus/pull/30860
+      QUARKUS_VERSION: 2.16.999-SNAPSHOT
     ids:
     - quarkus
   quarkus-lts:


### PR DESCRIPTION
Due to https://github.com/quarkusio/quarkus/pull/30860

- https://github.com/kiegroup/kogito-pipelines/pull/830
- https://github.com/kiegroup/drools/pull/4982
- https://github.com/kiegroup/optaplanner/pull/2578