### PR TITLE
[BXMSPROD-1938] backport PRs already merged

### DIFF
--- a/.ci/actions/backporting/action.yml
+++ b/.ci/actions/backporting/action.yml
@@ -88,7 +88,7 @@ runs:
         echo "BACKPORT_REVIEWERS=${reviewers}" >> $GITHUB_ENV
     - name: Perform cherry pick
       id: cherry-pick
-      uses: carloscastrojumo/github-cherry-pick-action@v1.0.6
+      uses: carloscastrojumo/github-cherry-pick-action@v1.0.9
       with:
         branch: "${{ inputs.target-branch }}"
         title: "[${{ inputs.target-branch }}] ${{ inputs.title }}"


### PR DESCRIPTION
**JIRA**:  https://issues.redhat.com/browse/BXMSPROD-1938

Referenced Pull Requests:
- https://github.com/carloscastrojumo/github-cherry-pick-action/pull/72

Upgrading `github-cherry-pick-action` to `1.0.9` we can backport PRs that have been already merged by simply labeling them. This can be also done if new commits have been added in the `main` branch (obviously if they are not conflicting with the one we want to backport).