### PR TITLE
remove reference to rhba-project-list-production in Jenkinsfile.prod.nightly

### DIFF
--- a/.ci/jenkins/Jenkinsfile.prod.nightly
+++ b/.ci/jenkins/Jenkinsfile.prod.nightly
@@ -56,9 +56,7 @@ pipeline {
                                 'droolsProductVersion': env.DROOLS_PRODUCT_VERSION, 
                                 'drools-scmRevision': getDroolsBranch(), 
                             ]
-                            configFileProvider([configFile(fileId: '49737697-ebd6-4396-9c22-11f7714808eb', variable: 'PRODUCTION_PROJECT_LIST')]) {
-                                pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/openshift-serverless-logic/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
-                            }
+                            pmebuild.buildProjects(projectCollection, "${SETTINGS_XML_ID}", "$WORKSPACE/build_config/openshift-serverless-logic/nightly", "${env.PME_CLI_PATH}", projectVariableMap, additionalVariables, [:])
                         }, 2, 480*60)
                     }
                 }


### PR DESCRIPTION
There is no reference of PRODUCTION_PROJECT_LIST variable being used in any place of the pipeline file, so removing it. It was probably some leftover when creating the pipeline in the past.