### PR TITLE
[BXMSPROD-1976] enable backporting from all branches

### DIFF
--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -3,8 +3,6 @@ name: Pull Request Backporting
 on:
   pull_request_target:
     types: [closed, labeled]
-    branches:
-      - main
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -32,7 +30,7 @@ jobs:
     strategy:
       matrix: 
         target-branch: ${{ fromJSON(needs.compute-targets.outputs.target-branches) }}
-      fail-fast: true
+      fail-fast: false
     steps:
       - name: Backporting
         uses: kiegroup/kogito-pipelines/.ci/actions/backporting@main


### PR DESCRIPTION
Enable PR backporting from all branches

**JIRA**: 

https://issues.redhat.com/browse/BXMSPROD-1976

*Referenced Pull Requests*:

- https://github.com/kiegroup/kogito-pipelines/pull/903
- https://github.com/kiegroup/kogito-runtimes/pull/2842
- https://github.com/kiegroup/kogito-examples/pull/1594
- https://github.com/kiegroup/kogito-apps/pull/1647
- https://github.com/kiegroup/drools/pull/5050
- https://github.com/kiegroup/optaplanner/pull/2660
- https://github.com/kiegroup/optaplanner-quickstarts/pull/529
- https://github.com/kiegroup/optaweb-vehicle-routing/pull/853
- https://github.com/kiegroup/optaplanner-website/pull/574
- https://github.com/kiegroup/kogito-serverless-operator/pull/82
- https://github.com/kiegroup/kogito-docs/pull/306
- https://github.com/kiegroup/kogito-images/pull/1455
- https://github.com/kiegroup/kogito-operator/pull/1402