### PR TITLE
[BXMSPROD-728] add action-junit-report

### DIFF
--- a/.ci/actions/action-junit-report/action.yml
+++ b/.ci/actions/action-junit-report/action.yml
@@ -1,0 +1,25 @@
+name: 'Action Junit Report'
+description: 'Generates a test report and annotates failures'
+inputs:
+  report_paths:
+    description: "Glob expression to surefire or failsafe report paths."
+    required: false
+    default: "**/**/TEST-*.xml"
+  annotate_only:
+    description: "Whether to publish test results as only annotation or not"
+    required: false
+    default: "true"
+  detailed_summary:
+    description: "Whether to publish a detailed test report or not"
+    required: false
+    default: "true"
+    
+runs:
+  using: "composite"
+  steps: 
+    - name: Publish Test Results
+      uses: mikepenz/action-junit-report@v3
+      with:
+        annotate_only: ${{ inputs.annotate_only }}
+        report_paths: ${{ inputs.report_paths }}
+        detailed_summary: ${{ inputs.detailed_summary }}


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/BXMSPROD-728

While we can't use checks run API since GitHub has a bug in their API (reported [here](https://github.com/orgs/community/discussions/14891) and [here](https://github.com/orgs/community/discussions/24616)), we can add annotations and produce a job summary that will indicate test failures. We will be able to achieve easy distinction between test failures and build failures as soon as we click on the checks that a PR ran.