### PR TITLE
[BXMSPROD-2018] Setup kogito status page

### DIFF
--- a/.ci/chain-status-info.md
+++ b/.ci/chain-status-info.md
@@ -1,0 +1,5 @@
+# Kiegroup Kogito organization repositories CI Status
+
+This project is based on [chain-status](https://github.com/kiegroup/chain-status) and information generated thanks to [build-chain-configuration-reader](https://github.com/kiegroup/build-chain-configuration-reader) using [kogito-pipelines definition file](https://github.com/kiegroup/kogito-pipelines/blob/main/.ci/pull-request-config.yaml).
+
+Due to the retrieved information requires a `GITHUB_TOKEN` and github API has a limitation it is better to not collect the information on every request from this webpage is made. So this webpage does not really requires an application service and all the required data is stored in github pages. This information is normally retrieved, treated and stored using [chain-status/action tool](https://github.com/kiegroup/chain-status/tree/main/packages/action) which is exposed as a Github Action tool, so we can customize the job execution frequency as we need.

--- a/.github/workflows/generate_status_page.yaml
+++ b/.github/workflows/generate_status_page.yaml
@@ -1,0 +1,19 @@
+name: Generate status page
+
+
+on: workflow_dispatch
+
+jobs:
+  generate-status-page:
+    if: github.repository_owner == 'kiegroup'
+    concurrency:
+      group: generate-status-page
+      cancel-in-progress: true
+    run-on: ubuntu-latest
+    name: Generate status page
+    steps:
+      - name: Generate status page
+        uses: kiegroup/chain-status/.ci/actions/generate-app@main
+        with:
+          info-md-url: "https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/.ci/chain-status-info.md"
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/generate_status_page_data.yaml
+++ b/.github/workflows/generate_status_page_data.yaml
@@ -1,0 +1,28 @@
+name: Generate status page data
+
+on:
+  workflow_dispatch:
+    schedule:
+      - cron: '0 * * * *'
+
+jobs:
+  generate-status-page-data:
+    if: github.repository_owner == 'kiegroup'
+    concurrency:
+      group: generate-status-page-data
+      cancel-in-progress: true
+    runs-on: ubuntu-latest
+    name: Generate status page data
+    steps:
+      - name: Generate status page data
+        uses: kiegroup/chain-status/.ci/actions/generate-data@main
+        with:
+          definition-file: https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/.ci/pull-request-config.yaml
+          title: Kogito Status
+          subtitle: Kiegroup Kogito organization repositories CI status
+          base-branch-filter: main,1.13.x,1.13.x-blue,8.13.x
+          branches: 1.13.x,1.13.x-blue
+          created-by: GitHub Action
+          created-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          logger-level: debug
+          github-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/generate_status_page_data.yaml
+++ b/.github/workflows/generate_status_page_data.yaml
@@ -14,13 +14,26 @@ jobs:
     runs-on: ubuntu-latest
     name: Generate status page data
     steps:
+      - uses: actions/checkout@v3
+        with:
+          path: ./kogito-pipelines
+      - name: Retrieve active repositories
+        id: retrieve_active_repos
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '[.repositories[].name] | join(",")' ./kogito-pipelines/dsl/config/branch.yaml
+      - name: Retrieve active branches
+        id: retrieve_active_branches
+        uses: mikefarah/yq@master
+        with:
+          cmd: yq '[.git.branches[].name] | join(",")' ./kogito-pipelines/dsl/config/main.yaml
       - name: Generate status page data
         uses: kiegroup/chain-status/.ci/actions/generate-data@main
         with:
-          definition-file: https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/.ci/pull-request-config.yaml
+          projects: "${{ steps.retrieve_active_repos.outputs.result }}"
           title: Kogito Status
           subtitle: Kiegroup Kogito organization repositories CI status
-          base-branch-filter: main,1.13.x,1.13.x-blue,8.13.x
+          base-branch-filter: "${{ steps.retrieve_active_branches.outputs.result }}"
           branches: 1.13.x,1.13.x-blue
           created-by: GitHub Action
           created-url: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}


### PR DESCRIPTION
**JIRA**: https://issues.redhat.com/browse/BXMSPROD-2018

This PR aims to setup Kogito status page like the one we have for Kiegroup https://kiegroup.github.io/droolsjbpm-build-bootstrap/status/kiegroup-status.

Here main configuration:

- Project list is taken from https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/.ci/pull-request-config.yaml 
```
definition-file: https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/.ci/pull-request-config.yaml
```

- Take into account the following branches when providing PRs infos
```
base-branch-filter: main,1.13.x,1.13.x-blue,8.13.x
```

- Provide branches comparison for the following two branches
```   
branches: 1.13.x,1.13.x-blue
```