### PR TITLE
Upgrade build-chain to v3

### DIFF
--- a/.ci/actions/build-chain/action.yml
+++ b/.ci/actions/build-chain/action.yml
@@ -9,8 +9,8 @@ inputs:
     required: false
     default: 'https://raw.githubusercontent.com/${GROUP:kiegroup}/kogito-pipelines/${BRANCH:main}/.ci/pull-request-config.yaml'
   flow-type:
-    description: "the flow to execute, it can be 'pull-request', 'full-downstream', 'single' or 'branch'"
-    default: "pull-request"
+    description: "the flow to execute, it can be 'cross_pr' (or 'pull-request' which is deprecated), 'full_downstream' (or 'full-downstream' which is deprecated), 'single_pr' (or 'single' which is deprecated) or 'branch'"
+    default: "croos_pr"
     required: false
   starting-project:
     description: "the project to start flow from. By default is the project triggering the job"
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: Build Chain Tool Execution
       id: build-chain
-      uses: kiegroup/github-action-build-chain@v2.6.25
+      uses: kiegroup/github-action-build-chain@v3
       with:
         definition-file: ${{ inputs.definition-file }}
         flow-type: ${{ inputs.flow-type }}


### PR DESCRIPTION
During [PR](https://github.com/kiegroup/drools/pull/5311) checks I noticed that `(build) drools` is failing because it still uses `build-chain:v2`:
```bash
[2023-06-15T07:33:15.097Z] + npm install -g '@kie/build-chain-action@^v2.6.25' -registry=https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/
[2023-06-15T07:33:16.023Z] npm ERR! code ETARGET
[2023-06-15T07:33:16.023Z] npm ERR! notarget No matching version found for @kie/build-chain-action@^v2.6.25.
[2023-06-15T07:33:16.023Z] npm ERR! notarget In most cases you or one of your dependencies are requesting
[2023-06-15T07:33:16.023Z] npm ERR! notarget a package version that doesn't exist.
[2023-06-15T07:33:16.023Z] 
[2023-06-15T07:33:16.023Z] npm ERR! A complete log of this run can be found in:
[2023-06-15T07:33:16.023Z] npm ERR!     /home/jenkins/.npm/_logs/2023-06-15T07_33_15_393Z-debug.log
script returned exit code 1
```