### PR TITLE
[1.29.x] Fix build-chain version to be installed

### DIFF
--- a/.ci/jenkins/Jenkinsfile.buildchain
+++ b/.ci/jenkins/Jenkinsfile.buildchain
@@ -58,7 +58,8 @@ pipeline {
             steps {
                 script {
                     println '[INFO] Getting build-chain version from composite action file'
-                    def buildChainVersion = buildChain.getBuildChainVersionFromCompositeActionFile()
+                    // if version is v2.y.z keep just v2
+                    def buildChainVersion = buildChain.getBuildChainVersionFromCompositeActionFile().split('\\.')[0]
                     if ([null, 'null'].contains(buildChainVersion)) {
                         def errorMessage = "[ERROR] The build-chain version can't be recovered. Please contact administrator"
                         println errorMessage


### PR DESCRIPTION
During [PR](https://github.com/kiegroup/drools/pull/5311) checks I noticed that `(build) drools` is failing because it still uses `build-chain:v2`, but the version it tries to download is not present on NPM as it was just GHA:
```bash
[2023-06-15T07:33:15.097Z] + npm install -g '@kie/build-chain-action@^v2.6.25' -registry=https://repository.engineering.redhat.com/nexus/repository/registry.npmjs.org/
[2023-06-15T07:33:16.023Z] npm ERR! code ETARGET
[2023-06-15T07:33:16.023Z] npm ERR! notarget No matching version found for @kie/build-chain-action@^v2.6.25.
[2023-06-15T07:33:16.023Z] npm ERR! notarget In most cases you or one of your dependencies are requesting
[2023-06-15T07:33:16.023Z] npm ERR! notarget a package version that doesn't exist.
[2023-06-15T07:33:16.023Z] 
[2023-06-15T07:33:16.023Z] npm ERR! A complete log of this run can be found in:
[2023-06-15T07:33:16.023Z] npm ERR!     /home/jenkins/.npm/_logs/2023-06-15T07_33_15_393Z-debug.log
script returned exit code 1
```

The fix aims to download from version `v2` instead of a specific full version.