### PR TITLE
[BXMSPROD-2064] set untrusted input as intermediate env variable

### DIFF
--- a/.ci/actions/parse-labels/action.yml
+++ b/.ci/actions/parse-labels/action.yml
@@ -36,5 +36,8 @@ runs:
         echo "targets=$(echo $targets)" >> $GITHUB_OUTPUT
     
     - name: Printing extracted targets
+      env:
+        # set untrusted input to intermediate env variable
+        TARGETS: ${{ steps.extract-targets.outputs.targets }}
       shell: bash
-      run: echo "Extracted target branches ${{ steps.extract-targets.outputs.targets }}"
+      run: echo "Extracted target branches $TARGETS"


### PR DESCRIPTION
**JIRA:** https://issues.redhat.com/browse/BXMSPROD-2064

**referenced Pull Requests:**
* https://github.com/kiegroup/kie-ci/pull/1514
* https://github.com/kiegroup/kogito-pipelines/pull/999
* https://github.com/kiegroup/droolsjbpm-build-bootstrap/pull/2321

As suggested here: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable setting untrusted input as env variable

> NOTE: even if we are planning to remove composite actions from this repo I would like to apply the change also here even if it will be needed for short time