### PR TITLE
[Apache] Allow repository job display name

### DIFF
--- a/dsl/seed/jenkinsfiles/Jenkinsfile.seed.branch
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.seed.branch
@@ -17,7 +17,7 @@ import org.kie.jenkins.jobdsl.utils.SeedJobUtils
 
 SeedJobUtils.createSeedJobTrigger(
     this,
-    "z-seed-trigger-${REPO_NAME}-job",
+    "z-seed-trigger-${JOB_DISPLAY_NAME}-job",
     "${REPO_NAME}",
     "${GIT_AUTHOR_NAME}",
     "${GIT_AUTHOR_CREDS_ID}",
@@ -130,6 +130,7 @@ pipeline {
                         // Add other repos `jenkins_config_path` var (useful if multijob PR checks for example)
                         envProps += all_repos.collectEntries {
                             [
+                                (generateEnvKey(it, 'job_display_name')): getRepoConfig(it).job_display_name,
                                 (generateEnvKey(it, 'jenkins_config_path')): getRepoConfig(it).git.jenkins_config_path,
                                 (generateEnvKey(it, 'git_branch')): getRepoConfig(it).git.branch,
                                 (generateEnvKey(it, 'git_author')): getRepoConfig(it).git.author.name,
@@ -170,6 +171,7 @@ pipeline {
                             GIT_AUTHOR_CREDS_ID: repoConfig.git.author.credentials_id,
                             GIT_JENKINS_CONFIG_PATH: repoConfig.git.jenkins_config_path,
                             JOB_NAME: "${JOB_NAME}",
+                            JOB_DISPLAY_NAME: repoConfig.job_display_name,
                             SEED_CONFIG_FILE_GIT_REPOSITORY: "${SEED_CONFIG_FILE_GIT_REPOSITORY}",
                             SEED_CONFIG_FILE_GIT_AUTHOR_NAME: "${SEED_CONFIG_FILE_GIT_AUTHOR_NAME}",
                             SEED_CONFIG_FILE_GIT_AUTHOR_CREDS_ID: "${SEED_CONFIG_FILE_GIT_AUTHOR_CREDS_ID}",
@@ -255,6 +257,8 @@ def getRepoConfig(String repository, String generationBranch = "${GENERATION_BRA
 
     def cfg = scriptUtils.deepCopyObject(branchConfig)
     cfg.remove('repositories')
+
+    cfg.job_display_name = repoConfig.job_display_name
 
     // In case repository is disabled
     cfg.disabled = repoConfig.disabled ?: false

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobUtils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobUtils.groovy
@@ -42,7 +42,7 @@ class KogitoJobUtils {
     *
     */
     static def createVersionUpdateToolsJob(def script, String repository, String dependencyName, def mavenUpdate = [:], def gradleUpdate = [:], def filepathReplaceRegex = [], def scriptCalls = []) {
-        def jobParams = JobParamsUtils.getSeedJobParams(script, "update-${dependencyName.toLowerCase()}-${repository}", JobType.TOOLS, 'Jenkinsfile.update-dependency-version', "Update ${dependencyName} version for ${repository}")
+        def jobParams = JobParamsUtils.getSeedJobParams(script, "update-${dependencyName.toLowerCase()}-${Utils.getRepositoryJobDisplayName(script, repository)}", JobType.TOOLS, 'Jenkinsfile.update-dependency-version', "Update ${dependencyName} version for ${repository}")
         JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(script, jobParams)
         // Setup correct checkout branch for pipelines
         jobParams.env.putAll([
@@ -178,7 +178,7 @@ class KogitoJobUtils {
     *
     */
     static def createEnvironmentIntegrationBranchNightlyJob(def script, String envName, def scriptCalls = [], Closure defaultJobParamsGetter = JobParamsUtils.DEFAULT_PARAMS_GETTER) {
-        def jobParams = JobParamsUtils.getSeedJobParamsWithEnv(script, "${Utils.getRepoName(script)}.integration", JobType.NIGHTLY, envName, 'Jenkinsfile.environment.integration-branch', "Generic Integration branch job for specific environment", defaultJobParamsGetter)
+        def jobParams = JobParamsUtils.getSeedJobParamsWithEnv(script, "${Utils.getJobDisplayName(script)}.integration", JobType.NIGHTLY, envName, 'Jenkinsfile.environment.integration-branch', "Generic Integration branch job for specific environment", defaultJobParamsGetter)
         jobParams.triggers = jobParams.triggers ?: [ cron : '@midnight' ] // To remove once environment nightlies are managed by main nightly pipeline
         if (!envName) {
             throw new RuntimeException('Please provide a non-empty environment to generate an integration branch job...')
@@ -237,7 +237,7 @@ class KogitoJobUtils {
     * See also `createBranchBuildChainJob` method
     */
     static def createNightlyBuildChainBuildAndTestJob(def script, String envName = '', String repository, Map extraEnv = [:], boolean enableNotification = false, Closure defaultJobParamsGetter = JobParamsUtils.DEFAULT_PARAMS_GETTER) {
-        def jobParams = JobParamsUtils.getSeedJobParamsWithEnv(script, "${repository}.build-and-test", JobType.NIGHTLY, envName, KogitoConstants.BUILD_CHAIN_JENKINSFILE, "Build & Test for ${repository} using the build-chain", defaultJobParamsGetter)
+        def jobParams = JobParamsUtils.getSeedJobParamsWithEnv(script, "${Utils.getRepositoryJobDisplayName(script, repository)}.build-and-test", JobType.NIGHTLY, envName, KogitoConstants.BUILD_CHAIN_JENKINSFILE, "Build & Test for ${repository} using the build-chain", defaultJobParamsGetter)
         jobParams.env.putAll(extraEnv)
         jobParams.triggers = jobParams.triggers ?: [ cron : '@midnight' ] // To remove once environment nightlies are managed by main nightly pipeline
         return createBranchBuildChainJob(script, jobParams, repository, enableNotification, envName)
@@ -258,7 +258,7 @@ class KogitoJobUtils {
     * See also `createBranchBuildChainJob` method
     */
     static def createNightlyBuildChainBuildAndDeployJob(def script, String envName = '', String repository, Map extraEnv = [:], boolean enableNotification = false, Closure defaultJobParamsGetter = JobParamsUtils.DEFAULT_PARAMS_GETTER) {
-        def jobParams = JobParamsUtils.getSeedJobParamsWithEnv(script, "${repository}.build-and-deploy", JobType.NIGHTLY, envName, KogitoConstants.BUILD_CHAIN_JENKINSFILE, "Build & Test for ${repository} using the build-chain", defaultJobParamsGetter)
+        def jobParams = JobParamsUtils.getSeedJobParamsWithEnv(script, "${Utils.getRepositoryJobDisplayName(script, repository)}.build-and-deploy", JobType.NIGHTLY, envName, KogitoConstants.BUILD_CHAIN_JENKINSFILE, "Build & Test for ${repository} using the build-chain", defaultJobParamsGetter)
         JobParamsUtils.setupJobParamsDeployConfiguration(script, jobParams)
         jobParams.env.putAll(extraEnv)
         return createBranchBuildChainJob(script, jobParams, repository, enableNotification, envName)
@@ -285,7 +285,7 @@ class KogitoJobUtils {
     *
     */
     static def createBuildChainIntegrationJob(def script, String envName, String repository, boolean enableNotification = false, Closure defaultJobParamsGetter = JobParamsUtils.DEFAULT_PARAMS_GETTER) {
-        def jobParams = JobParamsUtils.getSeedJobParamsWithEnv(script, "${repository}.integration", JobType.NIGHTLY, envName, KogitoConstants.BUILD_CHAIN_JENKINSFILE, "Integration with Quarkus for ${repository} using the build-chain", defaultJobParamsGetter)
+        def jobParams = JobParamsUtils.getSeedJobParamsWithEnv(script, "${Utils.getRepositoryJobDisplayName(script, repository)}.integration", JobType.NIGHTLY, envName, KogitoConstants.BUILD_CHAIN_JENKINSFILE, "Integration with Quarkus for ${repository} using the build-chain", defaultJobParamsGetter)
         if (!envName) {
             throw new RuntimeException('Please provide a non-empty environment to generate an integration branch job...')
         }

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
@@ -63,6 +63,14 @@ class Utils {
         return getBindingValue(script, 'REPO_NAME')
     }
 
+    static String getRepositoryJobDisplayName(def script, String repository) {
+        return getBindingValue(script, "${repository.toUpperCase()}_JOB_DISPLAY_NAME") ?: repository
+    }
+
+    static String getJobDisplayName(def script) {
+        return getRepositoryJobDisplayName(script, getRepoName(script))
+    }
+
     static String getGitBranch(def script) {
         return getBindingValue(script, 'GIT_BRANCH')
     }

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/utils/JobParamsUtils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/utils/JobParamsUtils.groovy
@@ -16,7 +16,7 @@ class JobParamsUtils {
         repository = repository ?: Utils.getRepoName(script)
         def jobParams = [
             job: [
-                name: repository,
+                name: Utils.getRepositoryJobDisplayName(script, repository),
             ],
             git: [
                 author: Utils.getGitAuthor(script),


### PR DESCRIPTION
can redefined the `prefix` for a repository job name
Example of future usage in Apache:
```
repositories:
- name: incubator-kie-kogito-runtimes
  job_display_name: kogito-runtimes
```

In that case, auto generated names like nightlies would keep the name as `kogito-runtimes.integration` or `kogito-runtimes.build-and-deploy` instead of `incubator-kogito-runtimes.integration`
This will help to perform less code changing in Jenkinsfiles with the migration to Apache