### PR TITLE
PR multibranchPipelineJob

### DIFF
--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
@@ -466,4 +466,41 @@ class KogitoJobTemplate {
         return "(.*${RegexUtils.getRegexFirstLetterCase('jenkins')},?.*(rerun|run) ${idStr}${testType}.*)"
     }
 
+    static def createPullRequestMultibranchPipelineJob(def script, String jenkinsFilePath = '.ci/jenkins/Jenkinsfile') {
+        script.folder("pullrequest_jobs")
+        return script.multibranchPipelineJob("pullrequest_jobs/${Utils.getRepoName(script)}-pr")?.with {
+            factory {
+                workflowBranchProjectFactory {
+                    scriptPath("${jenkinsFilePath}")
+                }
+            }
+            branchSources {
+                github {
+                    id("${Utils.getRepoName(script)}") // IMPORTANT: use a constant and unique identifier
+                    repoOwner("${Utils.getGitAuthor(script)}")
+                    repository("${Utils.getRepoName(script)}")
+                    checkoutCredentialsId("${Utils.getGitAuthorCredsId(script)}")
+                    scanCredentialsId("${Utils.getGitAuthorCredsId(script)}")
+                    // Build fork PRs (unmerged head).
+                    buildForkPRHead(false)
+                    // Build fork PRs (merged with base branch).
+                    buildForkPRMerge(true)
+                    // Build origin branches.
+                    buildOriginBranch(false)
+                    // Build origin branches also filed as PRs.
+                    buildOriginBranchWithPR(false)
+                    // Build origin PRs (unmerged head).
+                    buildOriginPRHead(false)
+                    // Build origin PRs (merged with base branch).
+                    buildOriginPRMerge(true)
+                }
+            }
+            orphanedItemStrategy {
+                discardOldItems {
+                    daysToKeep(10)
+                }
+            }
+        }
+    }
+
 }

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
@@ -468,7 +468,7 @@ class KogitoJobTemplate {
 
     static def createPullRequestMultibranchPipelineJob(def script, String jenkinsFilePath = '.ci/jenkins/Jenkinsfile') {
         script.folder('pullrequest_jobs')
-        return script.multibranchPipelineJob("pullrequest_jobs/${Utils.getRepoName(script)}-pr")?.with {
+        return script.multibranchPipelineJob("pullrequest_jobs/${Utils.getJobDisplayName(script)}-pr")?.with {
             triggers {
                 cron('H/5 * * * *')
             }

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
@@ -467,23 +467,23 @@ class KogitoJobTemplate {
     }
 
     static def createPullRequestMultibranchPipelineJob(def script, String jenkinsFilePath = '.ci/jenkins/Jenkinsfile') {
-        script.folder("pullrequest_jobs")
+        script.folder('pullrequest_jobs')
         return script.multibranchPipelineJob("pullrequest_jobs/${Utils.getRepoName(script)}-pr")?.with {
             triggers {
-                cron("*/5 * * * *")
+                cron('H/5 * * * *')
             }
             factory {
                 workflowBranchProjectFactory {
-                    scriptPath("${jenkinsFilePath}")
+                    scriptPath(jenkinsFilePath)
                 }
             }
             branchSources {
                 github {
-                    id("${Utils.getRepoName(script)}") // IMPORTANT: use a constant and unique identifier
-                    repoOwner("${Utils.getGitAuthor(script)}")
-                    repository("${Utils.getRepoName(script)}")
-                    checkoutCredentialsId("${Utils.getGitAuthorCredsId(script)}")
-                    scanCredentialsId("${Utils.getGitAuthorCredsId(script)}")
+                    id(Utils.getRepoName(script)) // IMPORTANT: use a constant and unique identifier
+                    repoOwner(Utils.getGitAuthor(script))
+                    repository(Utils.getRepoName(script))
+                    checkoutCredentialsId(Utils.getGitAuthorCredsId(script))
+                    scanCredentialsId(Utils.getGitAuthorCredsId(script))
                     // Build fork PRs (unmerged head).
                     buildForkPRHead(false)
                     // Build fork PRs (merged with base branch).

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
@@ -469,6 +469,9 @@ class KogitoJobTemplate {
     static def createPullRequestMultibranchPipelineJob(def script, String jenkinsFilePath = '.ci/jenkins/Jenkinsfile') {
         script.folder("pullrequest_jobs")
         return script.multibranchPipelineJob("pullrequest_jobs/${Utils.getRepoName(script)}-pr")?.with {
+            triggers {
+                cron("*/5 * * * *")
+            }
             factory {
                 workflowBranchProjectFactory {
                     scriptPath("${jenkinsFilePath}")


### PR DESCRIPTION
Adding a template for multibranchPipelineJob which using the github branch source plugin DSL defines a job that periodically polls given repository for new PRs from origin and from forks and executes given pipeline script (from that particular repo).