### PR TITLE
kie-issues#578 install freetype package using dnf

### DIFF
--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -33,6 +33,9 @@ sudo \
 wget \
 which \
 # system (END)
+# drools (BEGIN)
+freetype \
+# drools (END)
 && dnf clean all
 
 RUN sudo alternatives --install /usr/local/bin/python python $(which python${PYTHON_MAJOR_MINOR_VERSION}) 1 && \

--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -34,7 +34,10 @@ wget \
 which \
 # system (END)
 # drools (BEGIN)
+fontconfig \
 freetype \
+# couldn't get it for pre-defined repositories
+https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/overpass-fonts-3.0.4-8.el9.noarch.rpm \
 # drools (END)
 && dnf clean all
 


### PR DESCRIPTION
Adding freetype package which provides `libfreetype.so.6` that was reported as missing by Drools tests:
```
java.lang.UnsatisfiedLinkError: /home/nonrootuser/.sdkman/candidates/java/11.0.20-tem/lib/libfontmanager.so: libfreetype.so.6: cannot open shared object file: No such file or directory
```