### PR TITLE
kie-issues#581: start kogito-ci-build container with host network for PRs

### DIFF
--- a/dsl/scripts/pr_check.groovy
+++ b/dsl/scripts/pr_check.groovy
@@ -6,10 +6,11 @@ dockerGroups = [
 ]
 dockerArgs = [
     '-v /var/run/docker.sock:/var/run/docker.sock',
+    '--network host',
 ] + dockerGroups.collect { group -> "--group-add ${group}" }
 
 void launch() {
-    String builderImage = 'quay.io/kiegroup/kogito-ci-build:latest'
+    String builderImage = 'quay.io/kiegroup/kogito-ci-build:main-latest'
     sh "docker rmi -f ${builderImage} || true" // Remove before launching
 
     try {


### PR DESCRIPTION
kiegroup/kie-issues#581
Putting kogito-ci-build container on host network to be able to connect from tests to testcontainers.