### PR TITLE
Don't rebuild PR checks when origin changes

### DIFF
--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
@@ -490,17 +490,17 @@ class KogitoJobTemplate {
                     checkoutCredentialsId(Utils.getGitAuthorCredsId(script))
                     scanCredentialsId(Utils.getGitAuthorCredsId(script))
                     // Build fork PRs (unmerged head).
-                    buildForkPRHead(false)
+                    buildForkPRHead(true)
                     // Build fork PRs (merged with base branch).
-                    buildForkPRMerge(true)
+                    buildForkPRMerge(false)
                     // Build origin branches.
                     buildOriginBranch(false)
                     // Build origin branches also filed as PRs.
-                    buildOriginBranchWithPR(false)
+                    buildOriginBranchWithPR(true)
                     // Build origin PRs (unmerged head).
                     buildOriginPRHead(false)
                     // Build origin PRs (merged with base branch).
-                    buildOriginPRMerge(true)
+                    buildOriginPRMerge(false)
                 }
             }
             orphanedItemStrategy {

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
@@ -496,7 +496,7 @@ class KogitoJobTemplate {
                     // Build origin branches.
                     buildOriginBranch(false)
                     // Build origin branches also filed as PRs.
-                    buildOriginBranchWithPR(true)
+                    buildOriginBranchWithPR(false)
                     // Build origin PRs (unmerged head).
                     buildOriginPRHead(false)
                     // Build origin PRs (merged with base branch).


### PR DESCRIPTION
- Changes the behaviour of PR triggers in multibranch pipeline. It should run PR check only with the change, not rerunning it when the target branch changes.  