### PR TITLE
kie-issues#591: Install gcc in kogito-ci-build image

### DIFF
--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -28,6 +28,7 @@ krb5-devel \
 gcc \
 # python3 (END)
 # system (BEGIN)
+gcc-c++ \
 shadow-utils \
 sudo \
 wget \


### PR DESCRIPTION
Installing gcc using dnf to resolve apache/incubator-kie-issues#591.