### PR TITLE
Remove maven actions to follow Apache policies

### DIFF
--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -30,10 +30,27 @@ runs:
         distribution: 'temurin'
         java-version: ${{ inputs.java-version }}
         check-latest: true
-    - name: Set up Maven
-      uses: stCarolas/setup-maven@v4.2
+    # We have to download the required scripts to our local workspace
+    - name: Checkout Scripts
+      uses: actions/checkout@v4
       with:
-        maven-version: ${{ inputs.maven-version }}
+        repository: apache/incubator-kie-kogito-pipelines
+        sparse-checkout: |
+          .ci/actions/maven
+        path: maven-tools
+    - name: Cache Maven Download
+      id: cache-maven-download
+      uses: actions/cache@v3
+      with:
+        key: ${{ runner.os }}-maven-${{ inputs.maven-version }}
+        path: |
+          ~/.maven/download/
+    - name: Set up Maven
+      shell: bash
+      run: |
+        ./maven-tools/.ci/actions/maven/install-maven.sh "$HOME/.local/mvn"
+        echo "$HOME/.local/mvn/bin" >> $GITHUB_PATH
+        
     - name: Cache Maven packages
       uses: actions/cache@v3
       with:
@@ -48,70 +65,11 @@ runs:
         key: ${{ inputs.cache-key-prefix }}-m2-${{ hashFiles('**/pom.xml') }}
         restore-keys:  ${{ inputs.cache-key-prefix }}-m2
     - name: Setup Maven Settings
-      uses: whelk-io/maven-settings-xml-action@v21
-      with:
-        repositories: >
-          [
-            {
-              "id": "jboss-public-repository-group",
-              "name": "JBoss Public Repository Group",
-              "url": "https://repository.jboss.org/nexus/content/groups/public",
-              "releases": {
-                "enabled": "true",
-                "updatePolicy": "never"
-              },
-              "snapshots": {
-                "enabled": "${{ inputs.allow-snapshots }}",
-                "updatePolicy": "never"
-              }
-            },
-            {
-              "id": "kogito-staging-repository-group",
-              "name": "Kogito Staging Repositories",
-              "url": "https://repository.jboss.org/nexus/content/groups/kogito-public",
-              "releases": {
-                "enabled": "true",
-                "updatePolicy": "never"
-              },
-              "snapshots": {
-                "enabled": "${{ inputs.allow-snapshots }}",
-                "updatePolicy": "never"
-              }
-            }
-          ]
-        plugin_repositories: >
-          [
-            {
-              "id": "jboss-public-repository-group",
-              "name": "JBoss Public Repository Group",
-              "url": "https://repository.jboss.org/nexus/content/groups/public",
-              "releases": {
-                "enabled": "true",
-                "updatePolicy": "never"
-              },
-              "snapshots": {
-                "enabled": "${{ inputs.allow-snapshots }}",
-                "updatePolicy": "never"
-              }
-            },
-            {
-              "id": "kogito-staging-repository-group",
-              "name": "Kogito Staging Repositories",
-              "url": "https://repository.jboss.org/nexus/content/groups/kogito-public",
-              "releases": {
-                "enabled": "true",
-                "updatePolicy": "never"
-              },
-              "snapshots": {
-                "enabled": "${{ inputs.allow-snapshots }}",
-                "updatePolicy": "never"
-              }
-            }
-          ]
-        plugin_groups: >
-          [
-            "org.zanata"
-          ]
+      shell: bash
+      run: |
+        cp maven-tools/.ci/actions/maven/settings-template.xml ${HOME}/.m2/settings.xml
+        sed -i 's/{allow-snapshots}/${{ inputs.allow-snapshots }}/g' ${HOME}/.m2/settings.xml
+
     - name: Debug settings.xml
       if: ${{ inputs.debug }}
       shell: bash

--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -48,7 +48,7 @@ runs:
         path: |
           ~/.maven/download/
     - name: Set up Maven
-      shell: bash
+      shell: sh
       run: |
         ./maven-tools/.ci/actions/maven/install-maven.sh "$HOME/.local/mvn" ${{ inputs.maven-version }}
         echo "$HOME/.local/mvn/bin" >> $GITHUB_PATH

--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -33,8 +33,10 @@ runs:
     # We have to download the required scripts to our local workspace
     - name: Checkout Scripts
       uses: actions/checkout@v4
+      # For testing only, we will revert to apache once we test it
       with:
-        repository: apache/incubator-kie-kogito-pipelines
+        repository: ricardozanini/kogito-pipelines
+        ref: fix-migration-modules
         sparse-checkout: |
           .ci/actions/maven
         path: maven-tools

--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -33,10 +33,8 @@ runs:
     # We have to download the required scripts to our local workspace
     - name: Checkout Scripts
       uses: actions/checkout@v4
-      # For testing only, we will revert to apache once we test it
       with:
-        repository: ricardozanini/kogito-pipelines
-        ref: fix-migration-modules
+        repository: apache/incubator-kie-kogito-pipelines
         sparse-checkout: |
           .ci/actions/maven
         path: maven-tools

--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -48,7 +48,7 @@ runs:
     - name: Set up Maven
       shell: bash
       run: |
-        ./maven-tools/.ci/actions/maven/install-maven.sh "$HOME/.local/mvn"
+        ./maven-tools/.ci/actions/maven/install-maven.sh "$HOME/.local/mvn" ${{ inputs.maven-version }}
         echo "$HOME/.local/mvn/bin" >> $GITHUB_PATH
         
     - name: Cache Maven packages

--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -68,7 +68,6 @@ runs:
       shell: bash
       run: |
         cp maven-tools/.ci/actions/maven/settings-template.xml ${HOME}/.m2/settings.xml
-        sed -i 's/{allow-snapshots}/${{ inputs.allow-snapshots }}/g' ${HOME}/.m2/settings.xml
 
     - name: Debug settings.xml
       if: ${{ inputs.debug }}

--- a/.ci/actions/maven/install-maven.sh
+++ b/.ci/actions/maven/install-maven.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+set -e
+
+install_path=$1
+maven_version=$2
+
+if [[ -z ${maven_version} ]]; then
+  maven_version=$(curl https://maven.apache.org/download.cgi --silent | grep "Downloading Apache Maven " | grep -oE '[0-9].[0-9]+.[0-9]+')
+fi
+maven_file="apache-maven-${maven_version}-bin.tar.gz"
+download_url="http://www.mirrorservice.org/sites/ftp.apache.org/maven/maven-3/${maven_version}/binaries/${maven_file}"
+download_path="${HOME}/.maven/download/"
+
+echo "---> Maven version to install is ${maven_version}"
+
+if [ -e "${download_path}/${maven_file}" ]; then
+  echo "---> Maven ${maven_version} already exists in '${download_path}', skipping downloading"
+else
+  mkdir -p "${download_path}"
+  cd "${download_path}"
+  echo "---> Downloading maven ${maven_version} to ${download_path}"
+  curl -LO "${download_url}"
+  cd -
+fi
+
+if [ -z "${install_path}" ]; then
+  install_path="${HOME}/runner/mvn"
+fi
+
+echo "---> Ensuring maven installation at ${install_path}"
+
+mkdir -p "${install_path}"
+tar -f "${download_path}/${maven_file}" -zx --strip-components=1 -C ${install_path}
+
+sh "${install_path}/bin/mvn" --version

--- a/.ci/actions/maven/install-maven.sh
+++ b/.ci/actions/maven/install-maven.sh
@@ -30,6 +30,6 @@ fi
 echo "---> Ensuring maven installation at ${install_path}"
 
 mkdir -p "${install_path}"
-tar -f "${download_path}/${maven_file}" -zx --strip-components=1 -C ${install_path}
+tar -xf "${download_path}/${maven_file}" --strip-components=1 -C ${install_path}
 
 sh "${install_path}/bin/mvn" --version

--- a/.ci/actions/maven/install-maven.sh
+++ b/.ci/actions/maven/install-maven.sh
@@ -8,7 +8,7 @@ if [[ -z ${maven_version} ]]; then
   maven_version=$(curl https://maven.apache.org/download.cgi --silent | grep "Downloading Apache Maven " | grep -oE '[0-9].[0-9]+.[0-9]+')
 fi
 maven_file="apache-maven-${maven_version}-bin.tar.gz"
-download_url="http://www.mirrorservice.org/sites/ftp.apache.org/maven/maven-3/${maven_version}/binaries/${maven_file}"
+download_url="https://archive.apache.org/dist/maven/maven-3/${maven_version}/binaries/${maven_file}"
 download_path="${HOME}/.maven/download/"
 
 echo "---> Maven version to install is ${maven_version}"

--- a/.ci/actions/maven/settings-template.xml
+++ b/.ci/actions/maven/settings-template.xml
@@ -18,75 +18,8 @@
   <profiles>
     <!-- ### extra maven repositories ### -->
 
-    <profile>
-      <id>maven-action</id>
-      <repositories>
-        <repository>
-          <id>jboss-public-repository-group</id>
-          <name>JBoss Public Repository Group</name>
-          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-          <layout>default</layout>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>{allow-snapshots}</enabled>
-            <updatePolicy>never</updatePolicy>
-          </snapshots>
-        </repository>
-        <repository>
-          <id>kogito-staging-repository-group</id>
-          <name>Kogito Staging Repositories</name>
-          <url>https://repository.jboss.org/nexus/content/groups/kogito-public</url>
-          <layout>default</layout>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>{allow-snapshots}</enabled>
-            <updatePolicy>never</updatePolicy>
-          </snapshots>
-        </repository>
-        <!-- ### configured repositories ### -->
-      </repositories>
-
-      <pluginRepositories>
-        <pluginRepository>
-          <id>jboss-public-repository-group</id>
-          <name>JBoss Public Repository Group</name>
-          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
-          <layout>default</layout>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>{allow-snapshots}</enabled>
-            <updatePolicy>never</updatePolicy>
-          </snapshots>
-        </pluginRepository>
-        <pluginRepository>
-          <id>kogito-staging-repository-group</id>
-          <name>Kogito Staging Repositories</name>
-          <url>https://repository.jboss.org/nexus/content/groups/kogito-public</url>
-          <layout>default</layout>
-          <releases>
-            <enabled>true</enabled>
-            <updatePolicy>never</updatePolicy>
-          </releases>
-          <snapshots>
-            <enabled>{allow-snapshots}</enabled>
-            <updatePolicy>never</updatePolicy>
-          </snapshots>
-        </pluginRepository>
-        <!-- ### configured plugin repositories ### -->
-      </pluginRepositories>
-    </profile>
   </profiles>
   <activeProfiles>
     <!-- ### extra maven profile ### -->
-    <activeProfile>maven-action</activeProfile>
   </activeProfiles>
 </settings>

--- a/.ci/actions/maven/settings-template.xml
+++ b/.ci/actions/maven/settings-template.xml
@@ -1,0 +1,92 @@
+<settings xmlns="http://maven.apache.org/SETTINGS/1.0.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0
+                      https://maven.apache.org/xsd/settings-1.0.0.xsd">
+
+  <mirrors>
+    <!-- ### configured mirrors ### -->
+  </mirrors>
+
+  <proxies>
+    <!-- ### configured http proxy ### -->
+  </proxies>
+
+  <pluginGroups>
+    <pluginGroup>org.zanata</pluginGroup>
+  </pluginGroups>
+
+  <profiles>
+    <!-- ### extra maven repositories ### -->
+
+    <profile>
+      <id>maven-action</id>
+      <repositories>
+        <repository>
+          <id>jboss-public-repository-group</id>
+          <name>JBoss Public Repository Group</name>
+          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>{allow-snapshots}</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+        <repository>
+          <id>kogito-staging-repository-group</id>
+          <name>Kogito Staging Repositories</name>
+          <url>https://repository.jboss.org/nexus/content/groups/kogito-public</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>{allow-snapshots}</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </repository>
+        <!-- ### configured repositories ### -->
+      </repositories>
+
+      <pluginRepositories>
+        <pluginRepository>
+          <id>jboss-public-repository-group</id>
+          <name>JBoss Public Repository Group</name>
+          <url>https://repository.jboss.org/nexus/content/groups/public/</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>{allow-snapshots}</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+        <pluginRepository>
+          <id>kogito-staging-repository-group</id>
+          <name>Kogito Staging Repositories</name>
+          <url>https://repository.jboss.org/nexus/content/groups/kogito-public</url>
+          <layout>default</layout>
+          <releases>
+            <enabled>true</enabled>
+            <updatePolicy>never</updatePolicy>
+          </releases>
+          <snapshots>
+            <enabled>{allow-snapshots}</enabled>
+            <updatePolicy>never</updatePolicy>
+          </snapshots>
+        </pluginRepository>
+        <!-- ### configured plugin repositories ### -->
+      </pluginRepositories>
+    </profile>
+  </profiles>
+  <activeProfiles>
+    <!-- ### extra maven profile ### -->
+    <activeProfile>maven-action</activeProfile>
+  </activeProfiles>
+</settings>


### PR DESCRIPTION
In this PR:

- Remove setup maven and maven settings XML actions to include custom bash scripts to do the same thing
- Review actions to cache maven download and fetch this repo for a settings.xml reference file and a script to install maven

TODO:
- [x] - Test on my fork