### PR TITLE
Strict Build Chain version to whitelisted

### DIFF
--- a/.ci/actions/build-chain/action.yml
+++ b/.ci/actions/build-chain/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: Build Chain Tool Execution
       id: build-chain
-      uses: kiegroup/github-action-build-chain@v3
+      uses: kiegroup/github-action-build-chain@v3.4
       with:
         definition-file: ${{ inputs.definition-file }}
         flow-type: ${{ inputs.flow-type }}


### PR DESCRIPTION
In this PR, we strict the version used in [Build Chain](https://github.com/kiegroup/github-action-build-chain) to the one whitelisted by Apache.