### PR TITLE
kie-issues#651: introduce DISABLE_PR_CHECK config env variable

### DIFF
--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
@@ -482,6 +482,9 @@ class KogitoJobTemplate {
                     scriptPath(jenkinsFilePath)
                 }
             }
+            configure {
+                it / disabled << Utils.isPrCheckDisabled(script)
+            }
             branchSources {
                 github {
                     id(Utils.getRepoName(script)) // IMPORTANT: use a constant and unique identifier

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
@@ -283,4 +283,8 @@ class Utils {
         return getBindingValue(script, 'DISABLE_DEPLOY').toBoolean() || isTestEnvironment(script)
     }
 
+    static boolean isPrCheckDisabled(def script) {
+        return getBindingValue(script, 'DISABLE_PR_CHECK').toBoolean() || isTestEnvironment(script)
+    }
+
 }


### PR DESCRIPTION
apache/incubator-kie-issues#651

Introducing a utility method to disable PR checks for given project.
It disables them by default in "non-production" environment, when the seed or seed config author is not apache org to prevent unintended triggering of PR checks from test/temporary dsl config.