### PR TITLE
kie-issues#667: fix cleanup and settingsXml handling

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly.quarkus-platform
+++ b/.ci/jenkins/Jenkinsfile.nightly.quarkus-platform
@@ -28,7 +28,7 @@ pipeline {
         stage('Initialize') {
             steps {
                 script {
-                    cleanWs()
+                    cleanWs(disableDeferredWipeout: true)
                     sh 'printenv'
 
                     if (params.DISPLAY_NAME) {
@@ -175,7 +175,7 @@ pipeline {
     // Tests of platform should be done in a separate job
     }
     post {
-        always {
+        cleanup {
             cleanWs()
         }
         unsuccessful {

--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -206,6 +206,8 @@ pipeline {
             script {
                 saveReleaseProperties()
             }
+        }
+        cleanup {
             cleanWs()
         }
         success {

--- a/.ci/jenkins/Jenkinsfile.release.cloud
+++ b/.ci/jenkins/Jenkinsfile.release.cloud
@@ -273,6 +273,8 @@ pipeline {
             script {
                 saveReleaseProperties()
             }
+        }
+        cleanup {
             cleanWs()
         }
         success {

--- a/dsl/scripts/pr_check.groovy
+++ b/dsl/scripts/pr_check.groovy
@@ -89,6 +89,7 @@ void launchStages() {
                     withCredentials([string(credentialsId: 'SONARCLOUD_TOKEN', variable: 'TOKEN')]) {
                         new MavenCommand(this)
                                 .withProperty('sonar.login', "${TOKEN}")
+                                .withProperty('sonar.organization', 'apache') // override what's in pom.xml for now
                                 .withLogFileName('sonar_analysis.maven.log')
                                 .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
                                 .run("-e -nsu validate -Psonarcloud-analysis -Denforcer.skip=true ${env.SONARCLOUD_ANALYSIS_MVN_OPTS ?: ''}")

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
@@ -143,6 +143,7 @@ pipeline {
                                     withCredentials([string(credentialsId: 'SONARCLOUD_TOKEN', variable: 'TOKEN')]) {
                                         new MavenCommand(this)
                                             .withProperty('sonar.login', "${TOKEN}")
+                                            .withProperty('sonar.organization', 'apache') // override what's in pom.xml for now
                                             .withLogFileName('sonar_analysis.maven.log')
                                             .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
                                             .run("-e -nsu validate -Psonarcloud-analysis -Denforcer.skip=true ${env.SONARCLOUD_ANALYSIS_MVN_OPTS ?: ''}")

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
@@ -139,7 +139,15 @@ pipeline {
                     steps {
                         script {
                             dir(getProjectFolder()) {
-                                maven.runMavenWithSettingsSonar(settingsXmlId, "-e -nsu validate -Psonarcloud-analysis -Denforcer.skip=true ${env.SONARCLOUD_ANALYSIS_MVN_OPTS ?: ''}", 'SONARCLOUD_TOKEN', 'sonar_analysis.maven.log')
+                                configFileProvider([configFile(fileId: settingsXmlId, variable: 'MAVEN_SETTINGS_FILE')]) {
+                                    withCredentials([string(credentialsId: 'SONARCLOUD_TOKEN', variable: 'TOKEN')]) {
+                                        new MavenCommand(this)
+                                            .withProperty('sonar.login', "${TOKEN}")
+                                            .withLogFileName('sonar_analysis.maven.log')
+                                            .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
+                                            .run("-e -nsu validate -Psonarcloud-analysis -Denforcer.skip=true ${env.SONARCLOUD_ANALYSIS_MVN_OPTS ?: ''}")
+                                    }
+                                }
                             }
                         }
                     }

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
@@ -187,13 +187,6 @@ pipeline {
         cleanup {
             cleanWs()
         }
-        // cleanup {
-        //     script {
-        //         // Clean also docker in case of usage of testcontainers lib
-        //         util.cleanNode('docker')
-        //         sh 'rm -rf /tmp/quarkus'
-        //     }
-        // }
     }
 }
 

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.remove.branches
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.remove.branches
@@ -23,7 +23,7 @@ pipeline {
     stages{
         stage('CleanWorkspace') {
             steps {
-                cleanWs()
+                cleanWs(disableDeferredWipeout: true)
             }
         }
         stage('Initialize') {

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.seed.main
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.seed.main
@@ -167,7 +167,7 @@ pipeline {
     }
 }
     post {
-        always {
+        cleanup {
             cleanWs()
         }
         unsuccessful {

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.seed.trigger
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.seed.trigger
@@ -33,7 +33,7 @@ pipeline {
                 }
             }
             post {
-                always {
+                cleanup {
                     cleanWs()
                 }
             }

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.tools.toggle-triggers
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.tools.toggle-triggers
@@ -22,7 +22,7 @@ pipeline {
     stages {
         stage('CleanWorkspace') {
             steps {
-                cleanWs()
+                cleanWs(disableDeferredWipeout: true)
             }
         }
         stage('Initialize') {

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.update-quarkus-platform
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.update-quarkus-platform
@@ -26,7 +26,7 @@ pipeline {
     stages{
         stage('CleanWorkspace') {
             steps {
-                cleanWs()
+                cleanWs(disableDeferredWipeout: true)
             }
         }
 		stage('Initialize') {


### PR DESCRIPTION
apache/incubator-kie-issues#667

Fixing cleanup and settings.xml pipeline configuration to work correctly in ASF Jenkins.

* Deferred wipeout was causing issues when invoked in early stages
* Docker cleanup can't be done since the overall build is in docker container that uses the docker.sock from the host - it would attempt to erase itself.
* withSettingsXmlId shared library method does imply usage of a prohibited groovy method, thus replacing with explicit configFileProvider and passing as withSettingsXmlFile goes around that part of code. 

Complete list:
apache/incubator-kie-kogito-pipelines#1113
apache/incubator-kie-kogito-runtimes#3272
apache/incubator-kie-kogito-apps#1909
apache/incubator-kie-kogito-examples#1820
apache/incubator-kie-drools#5572
apache/incubator-kie-optaplanner#3010
apache/incubator-kie-optaplanner-quickstarts#613
apache/incubator-kie-kogito-docs#514
apache/incubator-kie-docs#4531
apache/incubator-kie-benchmarks#273