### PR TITLE
kie-issues#599: set projectKey for sonar analysis

### DIFF
--- a/dsl/scripts/pr_check.groovy
+++ b/dsl/scripts/pr_check.groovy
@@ -90,6 +90,7 @@ void launchStages() {
                         new MavenCommand(this)
                                 .withProperty('sonar.login', "${TOKEN}")
                                 .withProperty('sonar.organization', 'apache') // override what's in pom.xml for now
+                                .withProperty('sonar.projectKey', env.SONAR_PROJECT_KEY)
                                 .withLogFileName('sonar_analysis.maven.log')
                                 .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
                                 .run("-e -nsu validate -Psonarcloud-analysis -Denforcer.skip=true ${env.SONARCLOUD_ANALYSIS_MVN_OPTS ?: ''}")

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
@@ -144,6 +144,7 @@ pipeline {
                                         new MavenCommand(this)
                                             .withProperty('sonar.login', "${TOKEN}")
                                             .withProperty('sonar.organization', 'apache') // override what's in pom.xml for now
+                                            .withProperty('sonar.projectKey', env.SONAR_PROJECT_KEY)
                                             .withLogFileName('sonar_analysis.maven.log')
                                             .withSettingsXmlFile(MAVEN_SETTINGS_FILE)
                                             .run("-e -nsu validate -Psonarcloud-analysis -Denforcer.skip=true ${env.SONARCLOUD_ANALYSIS_MVN_OPTS ?: ''}")


### PR DESCRIPTION
apache/incubator-kie-issues#599

Explicitly setting sonar.projectKey in PR checks and buildchain nightly.

apache/incubator-kie-drools#5573
apache/incubator-kie-kogito-apps#1910
apache/incubator-kie-kogito-pipelines#1116
apache/incubator-kie-kogito-runtimes#3274
apache/incubator-kie-optaplanner#3011