### PR TITLE
kie-issue#675: fix install-maven.sh in maven GHA

### DIFF
--- a/.ci/actions/maven/install-maven.sh
+++ b/.ci/actions/maven/install-maven.sh
@@ -4,7 +4,7 @@ set -e
 install_path=$1
 maven_version=$2
 
-if [[ -z ${maven_version} ]]; then
+if [ -z "${maven_version}" ]; then
   maven_version=$(curl https://maven.apache.org/download.cgi --silent | grep "Downloading Apache Maven " | grep -oE '[0-9].[0-9]+.[0-9]+')
 fi
 maven_file="apache-maven-${maven_version}-bin.tar.gz"


### PR DESCRIPTION
apache/incubator-kie-issues#675

Fixing shell script, replacing bash built-in with shell construct.