### PR TITLE
kie-issues#628: add apache nexus credentials

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -90,8 +90,8 @@ maven:
     build_promotion_profile_id: TO_DEFINE
   artifacts_repository: ''
   artifacts_upload_repository:
-    url: TO_DEFINE
-    creds_id: TO_DEFINE
+    url: https://repository.apache.org/content/repositories/snapshots
+    creds_id: apache-nexus-kie-deploy-credentials
   quarkus_platform_repository:
     url: TO_DEFINE
     creds_id: TO_DEFINE


### PR DESCRIPTION
apache/incubator-kie-issues#628

Adding apache nexus credentials id into branch config file.