### PR TITLE
kie-issues#632: put cekit in /usr/local/bin

### DIFF
--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -132,6 +132,7 @@ RUN wget https://github.com/openshift/source-to-image/releases/download/v1.3.8/s
   ls ${tmp_dir} && \
   sudo mv ${tmp_dir}/s2i /usr/local/bin/ && \
   rm -rf ${tmp_dir} /tmp/source-to-image/*
+
 # gh cli
 RUN sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
   sudo dnf install -y gh

--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -124,14 +124,14 @@ RUN wget https://github.com/mislav/hub/releases/download/v2.14.2/hub-linux-amd64
   sudo alternatives --install /usr/local/bin/hub hub /opt/hub/bin/hub 1
 
 # Cekit
-RUN pip3.11 install cekit==4.8.0 behave lxml docker docker-squash elementPath pyyaml ruamel.yaml python-dateutil Jinja2 pykwalify colorlog click
+RUN pip3.11 install cekit==4.8.0 behave lxml docker docker-squash elementPath pyyaml ruamel.yaml python-dateutil Jinja2 pykwalify colorlog click && \
+  sudo alternatives --install /usr/local/bin/cekit cekit /home/nonrootuser/.local/bin/cekit 1
 RUN wget https://github.com/openshift/source-to-image/releases/download/v1.3.8/source-to-image-v1.3.8-980ca195-linux-amd64.tar.gz -P /tmp && \
   tmp_dir=$(mktemp -d) && \
   tar -C ${tmp_dir} -xzvf /tmp/source-to-image-v1.3.8-980ca195-linux-amd64.tar.gz && \
   ls ${tmp_dir} && \
   sudo mv ${tmp_dir}/s2i /usr/local/bin/ && \
   rm -rf ${tmp_dir} /tmp/source-to-image/*
-
 # gh cli
 RUN sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
   sudo dnf install -y gh

--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -125,7 +125,7 @@ RUN wget https://github.com/mislav/hub/releases/download/v2.14.2/hub-linux-amd64
 
 # Cekit
 RUN pip3.11 install cekit==4.8.0 behave lxml docker docker-squash elementPath pyyaml ruamel.yaml python-dateutil Jinja2 pykwalify colorlog click && \
-  sudo alternatives --install /usr/local/bin/cekit cekit /home/nonrootuser/.local/bin/cekit 1
+  sudo alternatives --install /usr/local/bin/cekit cekit ~/.local/bin/cekit 1
 RUN wget https://github.com/openshift/source-to-image/releases/download/v1.3.8/source-to-image-v1.3.8-980ca195-linux-amd64.tar.gz -P /tmp && \
   tmp_dir=$(mktemp -d) && \
   tar -C ${tmp_dir} -xzvf /tmp/source-to-image-v1.3.8-980ca195-linux-amd64.tar.gz && \


### PR DESCRIPTION
apache/incubator-kie-issues#632

Putting cekit into /usr/local/bin to make sure it's available to docker user even if no initialization script is invoked (like ~/.bashrc and similar).