### PR TITLE
kie-issues#710: turn kogito-ci-build to ubuntu dind image

### DIFF
--- a/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
+++ b/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
@@ -35,7 +35,7 @@ pipeline {
                         checkout scm
 
                         sh """
-                            docker build --build-arg SDKMAN_JAVA=11.0.20-tem -t ${env.IMAGE_NAME_TAG} -f apache-nodes/Dockerfile.kogito-ci-build .
+                            docker build --build-arg SDKMAN_JAVA=11.0.20-tem -t ${env.IMAGE_NAME_TAG} -f apache-nodes/Dockerfile.kogito-ci-build ./apache-nodes
                             docker tag ${env.IMAGE_NAME_TAG} ${env.IMAGE_NAME}:${GIT_COMMIT}
                             docker tag ${env.IMAGE_NAME_TAG} ${env.IMAGE_NAME}:${BRANCH_NAME}-latest
                         """
@@ -61,7 +61,7 @@ pipeline {
             agent {
                 docker {
                     image env.IMAGE_NAME_TAG
-                    args '-v /var/run/docker.sock:/var/run/docker.sock --group-add docker --group-add input --group-add render'
+                    args '--privileged --group-add docker'
                 }
             }
             steps {

--- a/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
+++ b/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
@@ -35,7 +35,7 @@ pipeline {
                         checkout scm
 
                         sh """
-                            docker build --build-arg SDKMAN_JAVA=11.0.20-tem -t ${env.IMAGE_NAME_TAG} -f apache-nodes/Dockerfile.kogito-ci-build ./apache-nodes
+                            docker build -t ${env.IMAGE_NAME_TAG} -f apache-nodes/Dockerfile.kogito-ci-build ./apache-nodes
                             docker tag ${env.IMAGE_NAME_TAG} ${env.IMAGE_NAME}:${GIT_COMMIT}
                             docker tag ${env.IMAGE_NAME_TAG} ${env.IMAGE_NAME}:${BRANCH_NAME}-latest
                         """

--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.2
+FROM cruizba/ubuntu-dind:latest
 
 SHELL ["/bin/bash", "-c"]
 
@@ -10,7 +10,7 @@ ARG PYTHON_MAJOR_MINOR_VERSION="3.11"
 # set locale to C.UTF-8
 ENV LANG='C.UTF-8'
 
-RUN dnf -y update && dnf install -y \
+RUN apt update && apt upgrade -y && apt install -y \
 # skdman deps (BEGIN)
 git \
 findutils \
@@ -21,88 +21,72 @@ zip \
 # skdman deps (END)
 # python3 (BEGIN)
 python${PYTHON_MAJOR_MINOR_VERSION} \
-python${PYTHON_MAJOR_MINOR_VERSION}-devel \
-python${PYTHON_MAJOR_MINOR_VERSION}-pip \
+python${PYTHON_MAJOR_MINOR_VERSION}-dev \
+python${PYTHON_MAJOR_VERSION}-pip \
 python${PYTHON_MAJOR_VERSION}-gssapi \
-krb5-devel \
-gcc \
+krb5-multidev \
 # python3 (END)
 # system (BEGIN)
-nc \
-procps-ng \
-shadow-utils \
+netcat \
+libvshadow-utils \
 sudo \
 wget \
-which \
 # system (END)
 # drools (BEGIN)
 fontconfig \
-freetype \
-# couldn't get it for pre-defined repositories
-https://mirror.stream.centos.org/9-stream/AppStream/aarch64/os/Packages/overpass-fonts-3.0.4-8.el9.noarch.rpm \
 # drools (END)
 # kogito python integration (BEGIN)
-gcc-c++ \
-libglvnd-glx \
+libglvnd0 \
 # kogito python integration (END)
-&& dnf clean all
-
 # Cypress dependencies install (BEGIN)
-# almalinux repo to provide UI dev libraries
-RUN echo -e '\
-[almalinux-appstream]\n\
-name=AlmaLinux $releasever - AppStream\n\
-mirrorlist=https://mirrors.almalinux.org/mirrorlist/$releasever/appstream\n\
-# baseurl=https://repo.almalinux.org/almalinux/$releasever/AppStream/$basearch/os/\n\
-gpgcheck=1\n\
-gpgkey=https://repo.almalinux.org/almalinux/9.2/AppStream/x86_64/os/RPM-GPG-KEY-AlmaLinux-9\n\
-enabled=1\n\
-countme=1\n\
-metadata_expire=86400\n\
-enabled_metadata=1\
-' > /etc/yum.repos.d/almalinux-appstream.repo && \
-dnf config-manager --add-repo /etc/yum.repos.d/almalinux-appstream.repo && \
-dnf install -y \
-xorg-x11-server-Xvfb \
-gtk2-devel \
-gtk3-devel \
-libnotify-devel \
-nss \
-libXScrnSaver \
-alsa-lib \
-&& dnf clean all \
-&& dnf config-manager --set-disabled almalinux-appstream
+xvfb \
+libgtk2.0-dev \
+libgtk-3-dev \
+libnotify-dev \
+libnss3-tools \
+libxss1 \
+libasound2 \
 # Cypress dependencies install (END)
+# kogito-images (BEGIN)
+skopeo \
+# kogito-images (END)
+&& apt clean
 
-RUN sudo alternatives --install /usr/local/bin/python python $(which python${PYTHON_MAJOR_MINOR_VERSION}) 1 && \
-  sudo alternatives --install /usr/local/bin/python3 python3 $(which python${PYTHON_MAJOR_MINOR_VERSION}) 1 && \
-  sudo alternatives --install /usr/local/bin/pip pip $(which pip${PYTHON_MAJOR_MINOR_VERSION}) 1
-
-RUN groupadd -g 910 nonrootuser && useradd -u 910 -g 910 nonrootuser && \
+RUN groupadd -g 910 nonrootuser && useradd -u 910 -g 910 -s /bin/bash -m nonrootuser && \
   echo "nonrootuser ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # Docker
-RUN  dnf -y update && dnf install -y yum-utils device-mapper-persistent-data lvm2 && \
-  dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo && \
-  dnf remove podman buildah && \
-  dnf install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin --nobest && \
-  dnf clean all && \
-  alternatives --install /usr/local/bin/docker-compose docker-compose /usr/libexec/docker/cli-plugins/docker-compose 1
+RUN groupadd docker && \
+  usermod -aG docker nonrootuser && \
+  newgrp docker
 
 USER nonrootuser
+
+# Install pip of given version (BEGIN)
+RUN curl -sS https://bootstrap.pypa.io/get-pip.py | python${PYTHON_MAJOR_MINOR_VERSION}
+# Install pip of given version (END)
+
+RUN sudo update-alternatives --install /usr/local/bin/python python $(which python${PYTHON_MAJOR_MINOR_VERSION}) 1 && \
+  sudo update-alternatives --install /usr/local/bin/python3 python3 $(which python${PYTHON_MAJOR_MINOR_VERSION}) 1 && \
+  sudo update-alternatives --install /usr/local/bin/pip pip ~/.local/bin/pip${PYTHON_MAJOR_MINOR_VERSION} -1 && \
+  sudo update-alternatives --install /usr/local/bin/pip${PYTHON_MAJOR_VERSION} pip${PYTHON_MAJOR_VERSION} ~/.local/bin/pip${PYTHON_MAJOR_MINOR_VERSION} -1 && \
+  sudo update-alternatives --install /usr/local/bin/pip${PYTHON_MAJOR_MINOR_VERSION} pip${PYTHON_MAJOR_MINOR_VERSION} ~/.local/bin/pip${PYTHON_MAJOR_MINOR_VERSION} -1
 
 RUN curl -s "https://get.sdkman.io" | bash && \
   source "$HOME/.sdkman/bin/sdkman-init.sh" && \
   sdk install java ${SDKMAN_JAVA} && \
-  sudo alternatives --install /usr/local/bin/java java $(which java) 1 && \
+  sudo update-alternatives --install /usr/local/bin/java java $(which java) 1 && \
   sdk install maven ${SDKMAN_MAVEN} && \
-  sudo alternatives --install /usr/local/bin/mvn mvn $(which mvn) 1 && \
+  sudo update-alternatives --install /usr/local/bin/mvn mvn $(which mvn) 1 && \
   sdk flush
   
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash && \
+  export NVM_DIR="$HOME/.nvm" && \
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh" && \
+  [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion" && \
   source ~/.bashrc && nvm install "v16.20.0" && \
-  sudo alternatives --install /usr/local/bin/node node $(which node) 1 && \
-  sudo alternatives --install /usr/local/bin/npm npm $(which npm) 1
+  sudo update-alternatives --install /usr/local/bin/node node $(which node) 1 && \
+  sudo update-alternatives --install /usr/local/bin/npm npm $(which npm) 1
   
 RUN wget https://go.dev/dl/go1.19.10.linux-amd64.tar.gz -P /tmp && \
   sudo mkdir /opt/golang && \
@@ -112,7 +96,7 @@ RUN wget https://go.dev/dl/go1.19.10.linux-amd64.tar.gz -P /tmp && \
   echo 'export GOPATH=${HOME}/go' | sudo tee /etc/profile.d/go.sh && \
   echo "source /etc/profile.d/go.sh" >> $HOME/.bashrc && \
   rm -rf /tmp/go* && \
-  sudo alternatives --install /usr/local/bin/go go /opt/golang/go/bin/go 1
+  sudo update-alternatives --install /usr/local/bin/go go /opt/golang/go/bin/go 1
 
 # Install hub CLI (used for GitHub api operations)
 RUN wget https://github.com/mislav/hub/releases/download/v2.14.2/hub-linux-amd64-2.14.2.tgz -O /tmp/hub.tgz && \
@@ -121,11 +105,12 @@ RUN wget https://github.com/mislav/hub/releases/download/v2.14.2/hub-linux-amd64
   sudo chown -R nonrootuser:nonrootuser /opt/hub/bin/hub && \
   sudo chmod -R 755 /opt/hub/bin/hub && \
   rm -rf /tmp/hub.tgz && \
-  sudo alternatives --install /usr/local/bin/hub hub /opt/hub/bin/hub 1
+  sudo update-alternatives --install /usr/local/bin/hub hub /opt/hub/bin/hub 1
 
 # Cekit
-RUN pip3.11 install cekit==4.8.0 behave lxml docker docker-squash elementPath pyyaml ruamel.yaml python-dateutil Jinja2 pykwalify colorlog click && \
-  sudo alternatives --install /usr/local/bin/cekit cekit ~/.local/bin/cekit 1
+RUN pip${PYTHON_MAJOR_MINOR_VERSION} install cekit==4.8.0 behave lxml docker docker-squash elementPath pyyaml ruamel.yaml python-dateutil Jinja2 pykwalify colorlog click && \
+  sudo update-alternatives --install /usr/local/bin/cekit cekit ~/.local/bin/cekit 1 && \
+  sudo update-alternatives --install /usr/local/bin/docker-squash docker-squash ~/.local/bin/docker-squash 1
 RUN wget https://github.com/openshift/source-to-image/releases/download/v1.3.8/source-to-image-v1.3.8-980ca195-linux-amd64.tar.gz -P /tmp && \
   tmp_dir=$(mktemp -d) && \
   tar -C ${tmp_dir} -xzvf /tmp/source-to-image-v1.3.8-980ca195-linux-amd64.tar.gz && \
@@ -134,8 +119,11 @@ RUN wget https://github.com/openshift/source-to-image/releases/download/v1.3.8/s
   rm -rf ${tmp_dir} /tmp/source-to-image/*
 
 # gh cli
-RUN sudo dnf config-manager --add-repo https://cli.github.com/packages/rpm/gh-cli.repo && \
-  sudo dnf install -y gh
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+  && sudo apt update \
+  && sudo apt install gh -y
 
 # Install kubectl
 RUN wget https://dl.k8s.io/release/$(curl -Ls https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl -P /tmp && \
@@ -148,6 +136,10 @@ RUN wget https://mirror.openshift.com/pub/openshift-v4/clients/ocp/latest-4.13/o
   tar -C ${tmp_dir} -xvf /tmp/openshift-client-linux.tar.gz && \
   sudo mv ${tmp_dir}/oc /usr/local/bin && \
   rm -rf ${tmp_dir} /tmp/openshift-client*
+
+# Convenience script to account for using 'alternatives' in some places
+RUN sudo bash -c 'echo -e "#!/bin/bash\nupdate-alternatives \"\$@\"" > /usr/local/bin/alternatives' \
+  && sudo chmod +x /usr/local/bin/alternatives
 
 ENV HOME="/home/nonrootuser/"
 
@@ -163,3 +155,12 @@ ENV CONTAINER_ENGINE="docker"
 ENV CONTAINER_ENGINE_TLS_OPTIONS=""
 
 WORKDIR /project/directory
+
+USER root
+COPY start-docker.sh entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/start-docker.sh \
+	/usr/local/bin/entrypoint.sh
+USER nonrootuser
+
+ENTRYPOINT ["entrypoint.sh"]
+CMD ["bash"]

--- a/apache-nodes/entrypoint.sh
+++ b/apache-nodes/entrypoint.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+# Start docker
+start-docker.sh
+
+# cgroup v2: enable nesting
+if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
+    echo "in cgroupv2 branch"
+	# move the processes from the root group to the /init group,
+	# otherwise writing subtree_control fails with EBUSY.
+	# An error during moving non-existent process (i.e., "cat") is ignored.
+	sudo mkdir -p /sys/fs/cgroup/init
+	sudo bash -c "xargs -rn1 < /sys/fs/cgroup/cgroup.procs > /sys/fs/cgroup/init/cgroup.procs || :"
+	# enable controllers
+	sudo bash -c "sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers > /sys/fs/cgroup/cgroup.subtree_control"
+fi
+
+if [ $# -gt 0 ]; then
+	exec "$@"
+fi

--- a/apache-nodes/start-docker.sh
+++ b/apache-nodes/start-docker.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+source /opt/bash-utils/logger.sh
+
+function wait_for_process () {
+    local max_time_wait=30
+    local process_name="$1"
+    local waited_sec=0
+    while ! pgrep "$process_name" >/dev/null && ((waited_sec < max_time_wait)); do
+        INFO "Process $process_name is not running yet. Retrying in 1 seconds"
+        INFO "Waited $waited_sec seconds of $max_time_wait seconds"
+        sleep 1
+        ((waited_sec=waited_sec+1))
+        if ((waited_sec >= max_time_wait)); then
+            return 1
+        fi
+    done
+    sudo chown root:docker /var/run/docker.sock
+    return 0
+}
+
+INFO "Starting supervisor"
+sudo bash -c "/usr/bin/supervisord >> /dev/null 2>&1" &
+
+INFO "Waiting for docker to be running"
+wait_for_process dockerd
+if [ $? -ne 0 ]; then
+    ERROR "dockerd is not running after max time"
+    exit 1
+else
+    INFO "dockerd is running"
+fi

--- a/dsl/scripts/pr_check.groovy
+++ b/dsl/scripts/pr_check.groovy
@@ -31,7 +31,7 @@ dockerArgs = [
 ] + dockerGroups.collect { group -> "--group-add ${group}" }
 
 void launch() {
-    String builderImage = 'quay.io/kiegroup/kogito-ci-build:main-latest'
+    String builderImage = 'quay.io/kiegroup/kogito-ci-build:19a0b303bc64f473a01f5fa5bacde822f10b4946' // last main-latest based on ubi
     sh "docker rmi -f ${builderImage} || true" // Remove before launching
 
     try {


### PR DESCRIPTION
apache/incubator-kie-issues#710

Switching the kogito-ci-build into ubuntu based dind image which will isolate container docker environment from the host one (as opposed to our previous solution by passing docker.sock).

The pipelines are currently generated with a fixed kogito-ci-build image tag, thus by merging this, we'll allow the build pipeline to build and push the new image under main-latest tag, only when that's successful, we'll switch pipelines back to using main-latest again. The reason is that docker args will change together with the image.