### PR TITLE
kie-issues#710: configure dind image

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -109,8 +109,8 @@ jenkins:
         # At some point, this image will need to be changed when a release branch is created 
         # but we need to make sure the image exists first ... simple tag before setting up the branch ?
         # See https://github.com/kiegroup/kie-issues/issues/551
-        image: quay.io/kiegroup/kogito-ci-build:19a0b303bc64f473a01f5fa5bacde822f10b4946 # last main-latest based on ubi
-        args: -v /var/run/docker.sock:/var/run/docker.sock --network host --group-add docker --group-add input --group-add render
+        image: quay.io/kiegroup/kogito-ci-build:main-latest
+        args: --privileged --group-add docker
   default_tools:
     jdk: jdk_11_latest
     maven: maven_3.8.6

--- a/dsl/scripts/pr_check.groovy
+++ b/dsl/scripts/pr_check.groovy
@@ -22,16 +22,13 @@ import org.kie.jenkins.MavenCommand
 // TODO Docker image and args could be passed as env or anything ?
 dockerGroups = [ 
     'docker',
-    'input',
-    'render',
 ]
 dockerArgs = [
-    '-v /var/run/docker.sock:/var/run/docker.sock',
-    '--network host',
+    '--privileged',
 ] + dockerGroups.collect { group -> "--group-add ${group}" }
 
 void launch() {
-    String builderImage = 'quay.io/kiegroup/kogito-ci-build:19a0b303bc64f473a01f5fa5bacde822f10b4946' // last main-latest based on ubi
+    String builderImage = 'quay.io/kiegroup/kogito-ci-build:main-latest'
     sh "docker rmi -f ${builderImage} || true" // Remove before launching
 
     try {


### PR DESCRIPTION
apache/incubator-kie-issues#710

Switching configuration to use docker in docker image variant now available under main-latest tag.

Follows-up on: apache/incubator-kie-kogito-pipelines#1125

Part of ensemble:
apache/incubator-kie-kogito-pipelines#1127
apache/incubator-kie-drools#5593
apache/incubator-kie-optaplanner#3026
