### PR TITLE
kie-issues#632: fix kogito-images jenkins pipelines

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -100,9 +100,9 @@ maven:
     creds_id: TO_DEFINE
 cloud:
   image:
-    registry_credentials: tradisso_registry_token # TODO set to `kogito-quay-token`
+    registry_credentials: quay_kiegroup_registry_token
     registry: quay.io
-    namespace: tradisso # TODO set to `kiegroup` after testing
+    namespace: kiegroup
     latest_git_branch: main
 jenkins:
   email_creds_id: KOGITO_CI_NOTIFICATION_EMAILS

--- a/.ci/jenkins/tests/src/test/groovy/org/kie/jenkins/JenkinsfileNightly.groovy
+++ b/.ci/jenkins/tests/src/test/groovy/org/kie/jenkins/JenkinsfileNightly.groovy
@@ -43,6 +43,7 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
         addEnvVar('GIT_BRANCH_NAME', 'BRANCH')
         addEnvVar('GIT_AUTHOR', 'AUTHOR')
         addEnvVar('GIT_AUTHOR_CREDS_ID', 'AUTHOR_CREDS_ID')
+        addEnvVar('GIT_AUTHOR_PUSH_CREDS_ID', 'AUTHOR_PUSH_CREDS_ID')
         addEnvVar('JENKINS_EMAIL_CREDS_ID', 'KOGITO_CI_EMAIL_TO')
         addEnvVar('STAGE_NAME', 'STAGE_NAME')
         addEnvVar('BUILD_NUMBER', 'BUILD_NUMBER')
@@ -73,9 +74,9 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
             'kogito-apps' : [:],
             'kogito-examples': [:],
         ])
-        assertTestCallstackContains('githubscm.resolveRepository', 'kogito-examples, AUTHOR, BRANCH, false, AUTHOR_CREDS_ID')
+        assertTestCallstackContains('githubscm.resolveRepository', 'incubator-kie-kogito-examples, AUTHOR, BRANCH, false, AUTHOR_CREDS_ID')
         assertTestCallstackContains('githubscm.createBranch', 'nightly-BRANCH')
-        assertTestCallstackContains('githubscm.pushObject', 'origin, nightly-BRANCH, AUTHOR_CREDS_ID')
+        assertTestCallstackContains('githubscm.pushObject', 'origin, nightly-BRANCH, AUTHOR_PUSH_CREDS_ID')
     }
 
     @Test
@@ -94,9 +95,9 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
             'kogito-examples': [:],
         ], true)
 
-        assertTestCallstackContains('githubscm.resolveRepository', 'kogito-examples, AUTHOR, BRANCH, false, AUTHOR_CREDS_ID')
+        assertTestCallstackContains('githubscm.resolveRepository', 'incubator-kie-kogito-examples, AUTHOR, BRANCH, false, AUTHOR_CREDS_ID')
         assertTestCallstackContains('githubscm.createBranch', 'nightly-BRANCH')
-        assertTestCallstackContains('githubscm.pushObject', 'origin, nightly-BRANCH, AUTHOR_CREDS_ID')
+        assertTestCallstackContains('githubscm.pushObject', 'origin, nightly-BRANCH, AUTHOR_PUSH_CREDS_ID')
     }
 
     @Test
@@ -122,9 +123,9 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
             'kogito-examples': [:],
         ])
 
-        assertTestCallstackContains('githubscm.resolveRepository', 'kogito-examples, AUTHOR, BRANCH, false, AUTHOR_CREDS_ID')
+        assertTestCallstackContains('githubscm.resolveRepository', 'incubator-kie-kogito-examples, AUTHOR, BRANCH, false, AUTHOR_CREDS_ID')
         assertTestCallstackContains('githubscm.createBranch', 'nightly-BRANCH')
-        assertTestCallstackContains('githubscm.pushObject', 'origin, nightly-BRANCH, AUTHOR_CREDS_ID')
+        assertTestCallstackContains('githubscm.pushObject', 'origin, nightly-BRANCH, AUTHOR_PUSH_CREDS_ID')
     }
 
     @Test
@@ -150,9 +151,9 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
             'kogito-examples': [:],
         ])
 
-        assertTestCallstackContains('githubscm.resolveRepository', 'kogito-examples, AUTHOR, BRANCH, false, AUTHOR_CREDS_ID')
+        assertTestCallstackContains('githubscm.resolveRepository', 'incubator-kie-kogito-examples, AUTHOR, BRANCH, false, AUTHOR_CREDS_ID')
         assertTestCallstackContains('githubscm.createBranch', 'nightly-BRANCH')
-        assertTestCallstackContains('githubscm.pushObject', 'origin, nightly-BRANCH, AUTHOR_CREDS_ID')
+        assertTestCallstackContains('githubscm.pushObject', 'origin, nightly-BRANCH, AUTHOR_PUSH_CREDS_ID')
     }
 
     @Test

--- a/.github/workflows/jenkins-dsl-downstream.yml
+++ b/.github/workflows/jenkins-dsl-downstream.yml
@@ -152,7 +152,7 @@ jobs:
           echo 'BASE_BRANCH=${{ github.base_ref }}' >> $GITHUB_ENV
 
       - name: DSL tests
-        uses: kiegroup/kie-ci/.ci/actions/dsl-tests@main
+        uses: apache/incubator-kie-kogito-pipelines/.ci/actions/dsl-tests@main
         with:
           project: kogito
           repository: ${{ matrix.repository }}
@@ -316,7 +316,7 @@ jobs:
           echo 'BASE_BRANCH=development' >> $GITHUB_ENV
       
       - name: DSL tests
-        uses: kiegroup/kie-ci/.ci/actions/dsl-tests@main
+        uses: apache/incubator-kie-kogito-pipelines/.ci/actions/dsl-tests@main
         with:
           project: optaplanner
           repository: ${{ matrix.repository }}
@@ -475,7 +475,7 @@ jobs:
           echo 'BASE_BRANCH=${{ github.base_ref }}' >> $GITHUB_ENV
       
       - name: DSL tests
-        uses: kiegroup/kie-ci/.ci/actions/dsl-tests@main
+        uses: apache/incubator-kie-kogito-pipelines/.ci/actions/dsl-tests@main
         with:
           project: drools
           repository: ${{ matrix.repository }}

--- a/.github/workflows/jenkins-tests.yml
+++ b/.github/workflows/jenkins-tests.yml
@@ -24,12 +24,6 @@ jobs:
       with:
         path: main
 
-    - name: Checkout shared libraries
-      uses: actions/checkout@v3
-      with:
-        repository: kiegroup/jenkins-pipeline-shared-libraries
-        path: shared-libs
-
     - name: Set up JDK 1.8
       uses: actions/setup-java@v3
       with:
@@ -47,7 +41,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: DSL tests
-      uses: kiegroup/kie-ci/.ci/actions/dsl-tests@main
+      uses: apache/incubator-kie-kogito-pipelines/.ci/actions/dsl-tests@main
       with:
         main-config-file-repo: apache/incubator-kie-kogito-pipelines
         main-config-file-path: .ci/jenkins/config/main.yaml

--- a/.github/workflows/pr-backporting.yml
+++ b/.github/workflows/pr-backporting.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Set target branches
         id: set-targets
-        uses: kiegroup/kie-ci/.ci/actions/parse-labels@main
+        uses: apache/incubator-kie-kogito-pipelines/.ci/actions/parse-labels@main
         with:
           labels: ${LABELS}
   
@@ -33,6 +33,6 @@ jobs:
       fail-fast: false
     steps:
       - name: Backporting
-        uses: kiegroup/kie-ci/.ci/actions/backporting@main
+        uses: apache/incubator-kie-kogito-pipelines/.ci/actions/backporting@main
         with:
           target-branch: ${{ matrix.target-branch }}

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
@@ -485,11 +485,11 @@ class KogitoJobTemplate {
         return "(.*${RegexUtils.getRegexFirstLetterCase('jenkins')},?.*(rerun|run) ${idStr}${testType}.*)"
     }
 
-    static def createPullRequestMultibranchPipelineJob(def script, String jenkinsFilePath = '.ci/jenkins/Jenkinsfile') {
+    static def createPullRequestMultibranchPipelineJob(def script, String jenkinsFilePath = '.ci/jenkins/Jenkinsfile', String folderName='pullrequest_jobs') {
         String jobName = "${Utils.getJobDisplayName(script)}-pr"
         PrintUtils.debug(script, "Create pull request multibranch job ${jobName}")
-        script.folder('pullrequest_jobs')
-        return script.multibranchPipelineJob("pullrequest_jobs/${Utils.getJobDisplayName(script)}-pr")?.with {
+        script.folder(folderName)
+        return script.multibranchPipelineJob("${folderName}/${Utils.getJobDisplayName(script)}-pr")?.with {
             triggers {
                 periodicFolderTrigger {
                     // The maximum amount of time since the last indexing that is allowed to elapse before an indexing is triggered.


### PR DESCRIPTION
Fixing for kogito-images pipelines:
* regression in pullrequest jobs' folder, adjusting so that can be overridden in kogito-images jobs.groovy.

Including changes to GHA workflows which were not yet updated after the transfer.

PR ensemble:
* apache/incubator-kie-kogito-images#1709
* ~kiegroup/jenkins-pipeline-shared-libraries#306~
* apache/incubator-kie-kogito-pipelines#1131
* apache/incubator-kie-kogito-pipelines#1129
