### PR TITLE
kie-issues#747: tweak CI image docker startup

### DIFF
--- a/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
+++ b/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
@@ -1,12 +1,12 @@
 import org.jenkinsci.plugins.workflow.libs.Library
 
-@Library('jenkins-pipeline-shared-libraries')_
-
 pipeline {
     agent {
         label 'ubuntu'
     }
-
+    libraries {
+        lib("jenkins-pipeline-shared-libraries@${BRANCH_NAME}")
+    }
     environment {
         DOCKER_CONFIG = "${WORKSPACE}/.docker"
 
@@ -65,8 +65,13 @@ pipeline {
                 }
             }
             steps {
+                echo 'Init docker'
+                script {
+                    util.waitForDocker()
+                }
                 echo 'Debug basics'
                 sh '''
+                    sh --version
                     locale
                     printenv
                 '''

--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -157,10 +157,19 @@ ENV CONTAINER_ENGINE_TLS_OPTIONS=""
 WORKDIR /project/directory
 
 USER root
-COPY start-docker.sh entrypoint.sh /usr/local/bin/
+COPY start-docker.sh wait-for-docker.sh wait-for-process.sh entrypoint.sh /usr/local/bin/
 RUN chmod +x /usr/local/bin/start-docker.sh \
-	/usr/local/bin/entrypoint.sh
+	/usr/local/bin/entrypoint.sh \
+  /usr/local/bin/wait-for-docker.sh \
+  /usr/local/bin/wait-for-process.sh
 USER nonrootuser
+
+RUN echo "source wait-for-docker.sh" >> ~/.bashrc
+
+# Use bash as default instead of dash (BEGIN)
+RUN sudo bash -c "echo \"dash dash/sh boolean false\" | debconf-set-selections"
+RUN sudo bash -c "DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash"
+# Use bash as default instead of dash (END)
 
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["bash"]

--- a/apache-nodes/entrypoint.sh
+++ b/apache-nodes/entrypoint.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 set -e
-# Start docker
-start-docker.sh
 
 # cgroup v2: enable nesting
 if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
-    echo "in cgroupv2 branch"
+	echo "in cgroupv2 branch"
 	# move the processes from the root group to the /init group,
 	# otherwise writing subtree_control fails with EBUSY.
 	# An error during moving non-existent process (i.e., "cat") is ignored.
@@ -15,6 +13,10 @@ if [ -f /sys/fs/cgroup/cgroup.controllers ]; then
 	sudo bash -c "sed -e 's/ / +/g' -e 's/^/+/' < /sys/fs/cgroup/cgroup.controllers > /sys/fs/cgroup/cgroup.subtree_control"
 fi
 
+# Start docker and print logs
+start-docker.sh
+
+# process the command passed, after docker is started
 if [ $# -gt 0 ]; then
 	exec "$@"
 fi

--- a/apache-nodes/start-docker.sh
+++ b/apache-nodes/start-docker.sh
@@ -1,31 +1,15 @@
 #!/bin/bash
 source /opt/bash-utils/logger.sh
 
-function wait_for_process () {
-    local max_time_wait=30
-    local process_name="$1"
-    local waited_sec=0
-    while ! pgrep "$process_name" >/dev/null && ((waited_sec < max_time_wait)); do
-        INFO "Process $process_name is not running yet. Retrying in 1 seconds"
-        INFO "Waited $waited_sec seconds of $max_time_wait seconds"
-        sleep 1
-        ((waited_sec=waited_sec+1))
-        if ((waited_sec >= max_time_wait)); then
-            return 1
-        fi
-    done
-    sudo chown root:docker /var/run/docker.sock
-    return 0
-}
-
 INFO "Starting supervisor"
 sudo bash -c "/usr/bin/supervisord >> /dev/null 2>&1" &
 
 INFO "Waiting for docker to be running"
-wait_for_process dockerd
+source wait-for-docker.sh
 if [ $? -ne 0 ]; then
     ERROR "dockerd is not running after max time"
     exit 1
 else
+    sudo chown root:docker /var/run/docker.sock
     INFO "dockerd is running"
 fi

--- a/apache-nodes/wait-for-docker.sh
+++ b/apache-nodes/wait-for-docker.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+source wait-for-process.sh
+
+wait_for_process dockerd

--- a/apache-nodes/wait-for-process.sh
+++ b/apache-nodes/wait-for-process.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+source /opt/bash-utils/logger.sh
+set -e
+function wait_for_process () {
+    local max_time_wait=30
+    local process_name="$1"
+    local waited_sec=0
+    while ! pgrep "$process_name" >/dev/null && ((waited_sec < max_time_wait)); do
+        INFO "Process $process_name is not running yet. Retrying in 1 seconds"
+        INFO "Waited $waited_sec seconds of $max_time_wait seconds"
+        sleep 1
+        ((waited_sec=waited_sec+1))
+        if ((waited_sec >= max_time_wait)); then
+            return 1
+        fi
+    done
+    INFO "Process $process_name successfully started."
+    return 0
+}

--- a/dsl/scripts/pr_check.groovy
+++ b/dsl/scripts/pr_check.groovy
@@ -40,8 +40,9 @@ void launch() {
 
 void launchInDocker(String builderImage) {
     docker.image(builderImage).inside(dockerArgs.join(' ')) {
-        // Debug. To be removed in the future
-        sh "printenv"
+        sh 'printenv > env_props'
+        archiveArtifacts artifacts: 'env_props'
+        util.waitForDocker()
         sh 'ls -last /var/run/docker.sock'
         try {
             launchStages()

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
@@ -62,6 +62,7 @@ pipeline {
                 script {
                     sh 'printenv > env_props'
                     archiveArtifacts artifacts: 'env_props'
+                    util.waitForDocker()
                     sh 'ls -last /var/run/docker.sock'
 
                     if (mavenDeployArtifacts) {

--- a/jenkins-pipeline-shared-libraries/vars/util.groovy
+++ b/jenkins-pipeline-shared-libraries/vars/util.groovy
@@ -547,3 +547,11 @@ String displayDurationFromSeconds(int durationInSec) {
     result += "${seconds}s"
     return result
 }
+
+/**
+ * Method to wait for dockerd to be started. Put in initial pipeline stages to make sure all starts in time.
+ */
+void waitForDocker() {
+    sleep(10) // give it some ahead time not to invoke docker exec immediately after container start
+    sh 'wait-for-docker.sh' // script in kogito-ci-build image itself put in /usr/local/bin
+}


### PR DESCRIPTION
Fixes
* apache/incubator-kie-issues#747

* Adding an extra script to kogito-ci-build image to allow waiting for dockerd to be started.
Reason is that Jenkins does not wait for entrypoint.sh to finish before it starts executing steps towards it. Thus sometimes the docker is not yet started and docker socket available.
* Adding also pipeline util method util.waitForDocker() which first sleeps for short period of time before invoking the wait script against the container - in some cases the waiting script's invocation seemed to be too early to be successful - jenkins would just hang.
Thanks to library definition changes in the Jenkinsfile.build-kogito-ci-image the jenkins library change was properly tested.
* Also included change to change default shell to bash, instead of dash.