### PR TITLE
kie-issues#752: kogito-ci-build start docker in background

### DIFF
--- a/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
+++ b/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
@@ -36,13 +36,13 @@ pipeline {
 
                         sh """
                             docker build -t ${env.IMAGE_NAME_TAG} -f apache-nodes/Dockerfile.kogito-ci-build ./apache-nodes
-                            docker tag ${env.IMAGE_NAME_TAG} ${env.IMAGE_NAME}:${GIT_COMMIT}
+                            docker tag ${env.IMAGE_NAME_TAG} ${env.IMAGE_NAME}:${env.GIT_COMMIT?:githubscm.getCommitHash()}
                             docker tag ${env.IMAGE_NAME_TAG} ${env.IMAGE_NAME}:${BRANCH_NAME}-latest
                         """
 
                         sh """
                             docker --config ${DOCKER_CONFIG} push ${env.IMAGE_NAME_TAG}
-                            docker --config ${DOCKER_CONFIG} push ${env.IMAGE_NAME}:${GIT_COMMIT}
+                            docker --config ${DOCKER_CONFIG} push ${env.IMAGE_NAME}:${env.GIT_COMMIT?:githubscm.getCommitHash()}
                             docker --config ${DOCKER_CONFIG} push ${env.IMAGE_NAME}:${BRANCH_NAME}-latest
                         """
                     }

--- a/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
+++ b/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
@@ -62,6 +62,7 @@ pipeline {
                 docker {
                     image env.IMAGE_NAME_TAG
                     args '--privileged --group-add docker'
+                    reuseNode true
                 }
             }
             steps {

--- a/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
+++ b/.ci/jenkins/Jenkinsfile.build-kogito-ci-image
@@ -62,7 +62,6 @@ pipeline {
                 docker {
                     image env.IMAGE_NAME_TAG
                     args '--privileged --group-add docker'
-                    reuseNode true
                 }
             }
             steps {

--- a/apache-nodes/start-docker.sh
+++ b/apache-nodes/start-docker.sh
@@ -4,12 +4,5 @@ source /opt/bash-utils/logger.sh
 INFO "Starting supervisor"
 sudo bash -c "/usr/bin/supervisord >> /dev/null 2>&1" &
 
-INFO "Waiting for docker to be running"
-source wait-for-docker.sh
-if [ $? -ne 0 ]; then
-    ERROR "dockerd is not running after max time"
-    exit 1
-else
-    sudo chown root:docker /var/run/docker.sock
-    INFO "dockerd is running"
-fi
+INFO "Starting docker"
+bash -c "source wait-for-docker.sh > /dev/null && sudo chown root:docker /var/run/docker.sock" &


### PR DESCRIPTION
apache/incubator-kie-issues#752

Starting docker in entrypoint.sh, but in background.

To make Jenkins docker plugin happy that container processes passed command immediately - because jenkins starts the container by running `docker run <image> cat` and expects `cat` is processed immediately (can't wait for docker to be started).

In local use we'd rely on .bashrc script to invoke wait-for-docker.sh, in pipeline we'll do explicitly.