### PR TITLE
kie-issues#764: fix push for root jobs

### DIFF
--- a/dsl/seed/jenkinsfiles/Jenkinsfile.release.prepare
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.release.prepare
@@ -49,7 +49,7 @@ pipeline {
                     def repositories = getRepositoriesToBranch()
 
                     dir(checkoutMainBranchSeedConfigFileRepo()) {
-                        getOrCreateGitBranch(newBranch, getMainBranchConfigFileGitAuthorCredentialsId())
+                        getOrCreateGitBranch(newBranch, getMainBranchConfigFileGitAuthorPushCredentialsId())
 
                         // Update branch config
                         def branchConfig = readYaml file: branchConfigFile
@@ -87,7 +87,7 @@ pipeline {
                 script {
                     // Create seed branch if not already exist
                     dir(checkoutSeedRepo()) {
-                        getOrCreateGitBranch(getSeedRepoReleaseBranch(), "${SEED_CREDENTIALS_ID}")
+                        getOrCreateGitBranch(getSeedRepoReleaseBranch(), "${SEED_PUSH_CREDENTIALS_ID}")
                     }
                 }
             }
@@ -257,14 +257,16 @@ void createBranches(List repositories) {
         String repoName = repoConfig.name
         String baseBranch = repoConfig.branch
         String releaseBranch = getReleaseBranchFromRepository(repoConfig.name)
+        String gitAuthorCredsId = repoConfig.author?.credentials_id ?: readMainBranchConfig().git.author.credentials_id
+        assert gitAuthorCredsId : "Cannot find any credentials Id for git author ${repoConfig.author.name}. Please check your branch seed config file."
         String gitAuthorPushCredsId = repoConfig.author?.push?.credentials_id ?: readMainBranchConfig().git.author.push.credentials_id
-        assert gitAuthorPushCredsId : "Cannot find any credentials Id for git author ${repoConfig.author.name}. Please check your branch seed config file."
+        assert gitAuthorPushCredsId : "Cannot find any push credentials Id for git author ${repoConfig.author.name}. Please check your branch seed config file."
         String gitAuthor = repoConfig.author?.name ?: readMainBranchConfig().git.author.name
 
         echo "Checkout repo ${gitAuthor}/${repoName} on branch ${baseBranch}"
         dir(repoName) {
             deleteDir()
-            checkout(githubscm.resolveRepository(repoName, gitAuthor, baseBranch, false, gitAuthorPushCredsId))
+            checkout(githubscm.resolveRepository(repoName, gitAuthor, baseBranch, false, gitAuthorCredsId))
             getOrCreateGitBranch(releaseBranch, gitAuthorPushCredsId)
         }
         // Update the branch with the new release branch

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.seed.main
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.seed.main
@@ -50,6 +50,7 @@ pipeline {
                         SEED_REPO: "${SEED_REPO}",
                         SEED_AUTHOR: "${SEED_AUTHOR}",
                         SEED_AUTHOR_CREDS_ID: "${SEED_AUTHOR_CREDS_ID}",
+                        SEED_AUTHOR_PUSH_CREDS_ID: readSeedConfig().seed.config_file.git.author.push.credentials_id, // temporary until extra entry in all configs
                         SEED_BRANCH: "${SEED_BRANCH}",
                         SEED_CONFIG_FILE_GIT_REPOSITORY: "${SEED_CONFIG_FILE_GIT_REPOSITORY}",
                         SEED_CONFIG_FILE_GIT_AUTHOR_NAME: "${SEED_CONFIG_FILE_GIT_AUTHOR_NAME}",
@@ -94,6 +95,7 @@ pipeline {
                             SEED_REPO: "${SEED_REPO}",
                             SEED_AUTHOR: "${SEED_AUTHOR}",
                             SEED_AUTHOR_CREDS_ID: "${SEED_AUTHOR_CREDS_ID}",
+                            SEED_AUTHOR_PUSH_CREDS_ID: branchConfigFileInfo.push_credentials,
                             SEED_BRANCH: branchInfo.seed?.branch ?: "${SEED_BRANCH}",
                             SEED_JENKINSFILE: branchConfigFileInfo.jenkinsfile,
                             SEED_CONFIG_FILE_GIT_REPOSITORY: branchConfigFileInfo.repository,

--- a/dsl/seed/jobs/root_jobs.groovy
+++ b/dsl/seed/jobs/root_jobs.groovy
@@ -65,6 +65,7 @@ KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         env('SEED_AUTHOR', Utils.getSeedAuthor(this))
         env('SEED_BRANCH', Utils.getSeedBranch(this))
         env('SEED_CREDENTIALS_ID', Utils.getSeedAuthorCredsId(this))
+        env('SEED_PUSH_CREDENTIALS_ID', Utils.getSeedAuthorPushCredsId(this))
     }
 }
 
@@ -96,6 +97,7 @@ if (nonMainBranches) {
             env('GIT_REPOSITORY', "${SEED_CONFIG_FILE_GIT_REPOSITORY}")
             env('GIT_AUTHOR', "${SEED_CONFIG_FILE_GIT_AUTHOR_NAME}")
             env('GIT_AUTHOR_CREDENTIALS_ID', "${SEED_CONFIG_FILE_GIT_AUTHOR_CREDS_ID}")
+            env('GIT_AUTHOR_PUSH_CREDENTIALS_ID', "${SEED_CONFIG_FILE_GIT_AUTHOR_PUSH_CREDS_ID}")
             env('GIT_BRANCH_TO_BUILD', "${SEED_CONFIG_FILE_GIT_BRANCH}")
             env('CONFIG_FILE_PATH', "${SEED_CONFIG_FILE_PATH}")
         }

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
@@ -230,6 +230,10 @@ class Utils {
         return getBindingValue(script, 'SEED_AUTHOR_CREDS_ID')
     }
 
+    static String getSeedAuthorPushCredsId(def script) {
+        return getBindingValue(script, 'SEED_AUTHOR_PUSH_CREDS_ID')
+    }
+
     static String getSeedBranch(def script) {
         return getBindingValue(script, 'SEED_BRANCH')
     }


### PR DESCRIPTION
Closes
* apache/incubator-kie-issues#764

Adjusting root_jobs.groovy to use push credentials.

With one temporary solution
* Branching seed repository with seed >config_file > git > author > push > credentials_id - would be same value and this way this does not need to span multiple repositories.