### PR TITLE
kie-issues#771: fix pullrequest.getAuthorAndRepoForPr() method

### DIFF
--- a/jenkins-pipeline-shared-libraries/test/vars/PullRequestSpec.groovy
+++ b/jenkins-pipeline-shared-libraries/test/vars/PullRequestSpec.groovy
@@ -32,4 +32,16 @@ class PullRequestSpec extends JenkinsPipelineSpecification {
         then:
         result == 'owner/repo'
     }
+
+    def "PR from fork with matching name getAuthorAndRepoForPr" () {
+        setup:
+        def env = [:]
+        env['CHANGE_FORK']='contributor'
+        env['CHANGE_URL']='https://github.com/owner/repo/pull/1'
+        groovyScript.getBinding().setVariable('env', env)
+        when:
+        def result = groovyScript.getAuthorAndRepoForPr()
+        then:
+        result == 'contributor/repo'
+    }
 }

--- a/jenkins-pipeline-shared-libraries/vars/pullrequest.groovy
+++ b/jenkins-pipeline-shared-libraries/vars/pullrequest.groovy
@@ -23,11 +23,18 @@ String getAuthorAndRepoForPr() {
     if (!env.CHANGE_FORK && !env.CHANGE_URL) {
         error "CHANGE_FORK neither CHANGE_URL variables are set. Are you sure you're running with Github Branch Source plugin?"
     }
+    def group = ''
+    def repository = ''
     if (env.CHANGE_FORK) {
-        return env.CHANGE_FORK
+        def parsedFork = env.CHANGE_FORK.split('/')
+        group = parsedFork[0]
+        if (parsedFork.length==2) {
+            repository = parsedFork[1]
+        }
     }
     String fullUrl = env.CHANGE_URL
     String urlWithoutProtocol = fullUrl.split('://')[1]
     String path = urlWithoutProtocol.substring(urlWithoutProtocol.indexOf('/'))
-    return path.substring(1, path.indexOf('/pull/'))
+    def parsedUrl = path.substring(1, path.indexOf('/pull/')).split('/')
+    return "${group?:parsedUrl[0]}/${repository?:parsedUrl[1]}"
 }


### PR DESCRIPTION
Closes
* apache/incubator-kie-issues#771

Adds a missing variant of env variables received by Github Branch Source Plugin - when a fork repository name equals target repository name, env.CHANGE_FORK does NOT contain the repository name.