### PR TITLE
kie-issues_751: switch to use different token_credentials_id

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -63,7 +63,7 @@ git:
     # Taken from https://ci-builds.apache.org/credentials/
     # Need to be verified
     credentials_id: 399061d0-5ab5-4142-a186-a52081fef742
-    token_credentials_id: ci-builds
+    token_credentials_id: kie-ci3-token
     push:
       credentials_id: 84811880-2025-45b6-a44c-2f33bef30ad2 # CI Push Access for KIE
       token_credentials_id: 41128c14-bb63-4708-9074-d20a318ee630 # GitHub Personal Access Token for KIE


### PR DESCRIPTION
Part of
* apache/incubator-kie-issues#751

ci-builds token does not have necessary permissions to access github rest api like:

```
curl -H 'Authorization: token ****' 'https://api.github.com/repos/apache/incubator-kie-kogito-images/forks?per_page=100&page=1'
```