### PR TITLE
NO-ISSUE: bump maven version

### DIFF
--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -3,7 +3,7 @@ FROM cruizba/ubuntu-dind:latest
 SHELL ["/bin/bash", "-c"]
 
 ARG SDKMAN_JAVA="17.0.8-tem"
-ARG SDKMAN_MAVEN="3.8.8"
+ARG SDKMAN_MAVEN="3.9.3"
 ARG PYTHON_MAJOR_VERSION="3"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.11"
 


### PR DESCRIPTION
We need to bump maven version in CI image now that quarkus3 changes are merged in main.