### PR TITLE
[kie-issues#784] Remove unneded environment CI configurations.

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -6,26 +6,6 @@ environments:
       ADDITIONAL_TIMEOUT: 720
     ids:
     - native
-  quarkus-main:
-    enabled: false
-    env_vars:
-      QUARKUS_BRANCH: main
-    ids:
-    - quarkus
-  quarkus-branch:
-    env_vars:
-      QUARKUS_BRANCH: '2.16'
-    ids:
-    - quarkus
-  quarkus-3:
-    pull_request_default_check: false
-    env_vars:
-      BUILD_MAVEN_TOOL: maven_3.9.3
-      BUILD_JDK_TOOL: jdk_17_latest
-      BUILD_MVN_OPTS: -Denforcer.skip
-    ids:
-    - quarkus
-    - quarkus3
   sonarcloud:
     auto_generation: false
     env_vars:
@@ -115,7 +95,7 @@ jenkins:
         image: quay.io/kiegroup/kogito-ci-build:main-latest
         args: --privileged --group-add docker
   default_tools:
-    jdk: jdk_11_latest
-    maven: maven_3.8.6
+    jdk: jdk_17_latest
+    maven: maven_3.9.3
     sonar_jdk: jdk_17_latest
   jobs_definition_file: .ci/jenkins/dsl/jobs.groovy

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -1,3 +1,5 @@
+generation_config:
+  missing_environment: ignore
 environments:
   native:
     env_vars:

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -59,17 +59,6 @@ setupNightlyJob()
 setupQuarkusPlatformJob(JobType.NIGHTLY)
 if (isMainStream()) {
     setupNightlyCloudJob()
-    setupQuarkus3NightlyJob()
-}
-
-KogitoJobUtils.createEnvironmentIntegrationBranchNightlyJob(this, 'quarkus-main')
-KogitoJobUtils.createEnvironmentIntegrationBranchNightlyJob(this, 'quarkus-lts')
-KogitoJobUtils.createEnvironmentIntegrationBranchNightlyJob(this, 'quarkus-branch')
-KogitoJobUtils.createEnvironmentIntegrationBranchNightlyJob(this, 'native-lts')
-KogitoJobUtils.createEnvironmentIntegrationBranchNightlyJob(this, 'quarkus-3', []) { script ->
-    def jobParams = JobParamsUtils.DEFAULT_PARAMS_GETTER(script)
-    jobParams.env.put('INTEGRATION_BRANCH_CURRENT', '2.x')
-    return jobParams
 }
 
 // Release
@@ -209,43 +198,6 @@ void setupNightlyCloudJob() {
 
             booleanParam('USE_TEMP_OPENSHIFT_REGISTRY', false, 'If enabled, use Openshift registry to push temporary images')
         }
-    }
-}
-
-void setupQuarkus3NightlyJob() {
-    // Tests are done on 9.x/2.x branch => Create 2.x branch on Kogito
-    // Need to split as Drools and Kogito end up in different integration branches
-    KogitoJobUtils.createNightlyBuildChainIntegrationJob(this, 'quarkus-3', 'drools', true) { script ->
-        def jobParams = JobParamsUtils.getDefaultJobParams(script, 'incubator-kie-drools')
-        jobParams.git.branch = VersionUtils.getProjectTargetBranch('drools', Utils.getGitBranch(this), Utils.getRepoName(this))
-        jobParams.env.put('ADDITIONAL_TIMEOUT', '180')
-        jobParams.env.put('BUILD_ENVIRONMENT_OPTIONS_CURRENT', 'rewrite push_changes')
-        jobParams.env.put('INTEGRATION_BRANCH_CURRENT', '9.x')
-        // jobParams.env.put('LAUNCH_DOWNSTREAM_JOBS', 'kie-jpmml-integration.integration,kogito-runtimes.integration')
-        jobParams.env.put('LAUNCH_DOWNSTREAM_JOBS', 'kogito-runtimes.integration')
-        jobParams.parametersValues.put('SKIP_TESTS', true)
-        jobParams.parametersValues.put('SKIP_INTEGRATION_TESTS', true)
-        return jobParams
-    }
-    // Commented as not migrated to Apache
-    // KogitoJobUtils.createBuildChainIntegrationJob(this, 'quarkus-3', 'kie-jpmml-integration', true) { script ->
-    //     def jobParams = JobParamsUtils.getDefaultJobParams(script, 'incubator-kie-jpmml-integration')
-    //     jobParams.env.put('ADDITIONAL_TIMEOUT', '180')
-    //     jobParams.env.put('BUILD_ENVIRONMENT_OPTIONS_CURRENT', 'rewrite push_changes')
-    //     jobParams.env.put('INTEGRATION_BRANCH_CURRENT', '9.x')
-    //     jobParams.parametersValues.put('SKIP_TESTS', true)
-    //     jobParams.parametersValues.put('SKIP_INTEGRATION_TESTS', true)
-    //     return jobParams
-    // }
-    KogitoJobUtils.createBuildChainIntegrationJob(this, 'quarkus-3', 'kogito-runtimes', true) { script ->
-        def jobParams = JobParamsUtils.getDefaultJobParams(script, 'incubator-kie-kogito-runtimes')
-        jobParams.env.put('ADDITIONAL_TIMEOUT', '720')
-        jobParams.env.put('BUILD_ENVIRONMENT_OPTIONS_CURRENT', 'rewrite push_changes')
-        jobParams.env.put('INTEGRATION_BRANCH_CURRENT', '2.x')
-        jobParams.env.put('BUILDCHAIN_FULL_BRANCH_DOWNSTREAM_BUILD', 'true')
-        jobParams.parametersValues.put('SKIP_TESTS', true)
-        jobParams.parametersValues.put('SKIP_INTEGRATION_TESTS', true)
-        return jobParams
     }
 }
 


### PR DESCRIPTION
Removes unnecessary CI environments and scripts, like OpenRewrite scripts for Quarkus 3, etc.

Related PRs: 
Drools PR: https://github.com/apache/incubator-kie-drools/pull/5633
kogito-runtimes PR: https://github.com/apache/incubator-kie-kogito-runtimes/pull/3338
kogito-apps PR: https://github.com/apache/incubator-kie-kogito-apps/pull/1940
kogito-examples PR: https://github.com/apache/incubator-kie-kogito-examples/pull/1847
optaplanner PR: https://github.com/apache/incubator-kie-optaplanner/pull/3055