### PR TITLE
kie-issues#768 - Use Github CLI instead of hub CLI in jenkins shared libraries

### DIFF
--- a/jenkins-pipeline-shared-libraries/pom.xml
+++ b/jenkins-pipeline-shared-libraries/pom.xml
@@ -624,7 +624,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>jira</artifactId>
-            <version>3.0.8</version>
+            <version>3.12</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/jenkins-pipeline-shared-libraries/test/vars/GithubScmSpec.groovy
+++ b/jenkins-pipeline-shared-libraries/test/vars/GithubScmSpec.groovy
@@ -600,7 +600,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")('gh pr review pullRequestLink --approve"')
+        1 * getPipelineMock("sh")('gh pr review pullRequestLink --approve')
     }
 
     def "[githubscm.groovy] tagRepository with buildTag"() {

--- a/jenkins-pipeline-shared-libraries/test/vars/GithubScmSpec.groovy
+++ b/jenkins-pipeline-shared-libraries/test/vars/GithubScmSpec.groovy
@@ -522,7 +522,7 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         groovyScript.getBinding().setVariable("GITHUB_USER", 'user')
         groovyScript.getBinding().setVariable("GITHUB_TOKEN", 'password')
         when:
-        def result = groovyScript.executeGHCli('Command', 'credentialsId')
+        def result = groovyScript.executeGHCli('command', 'credentialsId')
         then:
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'credentialsId', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)

--- a/jenkins-pipeline-shared-libraries/test/vars/GithubScmSpec.groovy
+++ b/jenkins-pipeline-shared-libraries/test/vars/GithubScmSpec.groovy
@@ -364,14 +364,12 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         groovyScript.forkRepo()
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'kie-ci', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
 
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")('git config hub.protocol https')
-        1 * getPipelineMock("sh")('hub fork --remote-name=origin')
+        1 * getPipelineMock("sh")('gh repo fork --remote-name=origin')
         1 * getPipelineMock("sh")('git remote -v')
     }
 
@@ -382,14 +380,12 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         groovyScript.forkRepo('credentialsId')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'credentialsId', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
 
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")('git config hub.protocol https')
-        1 * getPipelineMock("sh")('hub fork --remote-name=origin')
+        1 * getPipelineMock("sh")('gh repo fork --remote-name=origin')
         1 * getPipelineMock("sh")('git remote -v')
     }
 
@@ -400,12 +396,11 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         def result = groovyScript.createPR('PR Title')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'kie-ci', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "hub pull-request -m 'PR Title' -m '' -b 'main'"]) >> 'shResult'
+        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "gh pr create -t 'PR Title' -b '' -B 'main'"]) >> 'shResult'
     }
 
     def "[githubscm.groovy] createPR without Credentials and target branch"() {
@@ -415,12 +410,11 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         def result = groovyScript.createPR('PR Title', 'PR body.')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'kie-ci', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "hub pull-request -m 'PR Title' -m 'PR body.' -b 'main'"]) >> 'shResult'
+        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "gh pr create -t 'PR Title' -b 'PR body.' -B 'main'"]) >> 'shResult'
     }
 
     def "[githubscm.groovy] createPR without Credentials and target branch throwing exception"() {
@@ -430,12 +424,11 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         def result = groovyScript.createPR('PR Title')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'kie-ci', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "hub pull-request -m 'PR Title' -m '' -b 'main'"]) >> { throw new Exception('error') }
+        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "gh pr create -t 'PR Title' -b '' -B 'main'"]) >> { throw new Exception('error') }
         thrown(Exception)
     }
 
@@ -446,12 +439,11 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         def result = groovyScript.createPR('PR Title', 'PR body.', 'targetBranch', 'credentialsId')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'credentialsId', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "hub pull-request -m 'PR Title' -m 'PR body.' -b 'targetBranch'"]) >> 'shResult'
+        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "gh pr create -t 'PR Title' -b 'PR body.' -B 'targetBranch'"]) >> 'shResult'
     }
 
     def "[githubscm.groovy] createPrAsDraft without body, Credentials and target branch"() {
@@ -461,12 +453,11 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         def result = groovyScript.createPrAsDraft('PR Title')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'kie-ci', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "hub pull-request -d -m 'PR Title' -m '' -b 'main'"]) >> 'shResult'
+        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "gh pr create -d -t 'PR Title' -b '' -B 'main'"]) >> 'shResult'
     }
 
     def "[githubscm.groovy] createPrAsDraft without Credentials and target branch"() {
@@ -476,12 +467,11 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         def result = groovyScript.createPrAsDraft('PR Title', 'PR body.')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'kie-ci', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "hub pull-request -d -m 'PR Title' -m 'PR body.' -b 'main'"]) >> 'shResult'
+        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "gh pr create -d -t 'PR Title' -b 'PR body.' -B 'main'"]) >> 'shResult'
     }
 
     def "[githubscm.groovy] createPrAsDraft without Credentials and target branch throwing exception"() {
@@ -491,12 +481,11 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         def result = groovyScript.createPrAsDraft('PR Title')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'kie-ci', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "hub pull-request -d -m 'PR Title' -m '' -b 'main'"]) >> { throw new Exception('draft error') }
+        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "gh pr create -d -t 'PR Title' -b '' -B 'main'"]) >> { throw new Exception('draft error') }
         thrown(Exception)
     }
 
@@ -507,12 +496,11 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         def result = groovyScript.createPrAsDraft('PR Title', 'PR body.', 'targetBranch', 'credentialsId')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'credentialsId', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "hub pull-request -d -m 'PR Title' -m 'PR body.' -b 'targetBranch'"]) >> 'shResult'
+        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "gh pr create -d -t 'PR Title' -b 'PR body.' -B 'targetBranch'"]) >> 'shResult'
     }
 
     def "[githubscm.groovy] createPRWithLabels with body, Credentials and target branch"() {
@@ -522,27 +510,25 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         def result = groovyScript.createPRWithLabels('PR Title', 'PR body.', 'targetBranch', ['label1', 'label2'] as String[], 'credentialsId')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'credentialsId', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "hub pull-request -m 'PR Title' -m 'PR body.' -b 'targetBranch' -l 'label1','label2'"]) >> 'shResult'
+        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "gh pr create -t 'PR Title' -b 'PR body.' -B 'targetBranch' -l 'label1','label2'"]) >> 'shResult'
     }
 
-    def "[githubscm.groovy] executeHub with credentials"() {
+    def "[githubscm.groovy] executeGHCli with credentials"() {
         setup:
         groovyScript.getBinding().setVariable("GITHUB_USER", 'user')
         groovyScript.getBinding().setVariable("GITHUB_TOKEN", 'password')
         when:
-        def result = groovyScript.executeHub('hubCommand', 'credentialsId')
+        def result = groovyScript.executeGHCli('Command', 'credentialsId')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'credentialsId', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "hubCommand"]) >> 'shResult'
+        1 * getPipelineMock("sh")(['returnStdout': true, 'script': "command"]) >> 'shResult'
     }
 
     def "[githubscm.groovy] mergePR without Credentials"() {
@@ -552,12 +538,11 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         groovyScript.mergePR('pullRequestLink')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'kie-ci', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")('hub merge pullRequestLink')
+        1 * getPipelineMock("sh")('gh pr merge --admin --rebase --delete-branch pullRequestLink')
     }
 
     def "[githubscm.groovy] mergePR without Credentials throwing exception"() {
@@ -567,12 +552,11 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         groovyScript.mergePR('pullRequestLink')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'kie-ci', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")('hub merge pullRequestLink') >> { throw new Exception('hub error') }
+        1 * getPipelineMock("sh")('gh pr merge --admin --rebase --delete-branch pullRequestLink') >> { throw new Exception('merge error') }
         thrown(Exception)
     }
 
@@ -583,12 +567,40 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         when:
         groovyScript.mergePR('pullRequestLink', 'credentialsId')
         then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
         1 * getPipelineMock('usernamePassword.call')([credentialsId: 'credentialsId', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
         1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
         1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
         1 * getPipelineMock("sh")('git config user.name user')
-        1 * getPipelineMock("sh")('hub merge pullRequestLink')
+        1 * getPipelineMock("sh")('gh pr merge --admin --rebase --delete-branch pullRequestLink')
+    }
+
+    def "[githubscm.groovy] approvePR without Credentials throwing exception"() {
+        setup:
+        groovyScript.getBinding().setVariable("GITHUB_USER", 'user')
+        groovyScript.getBinding().setVariable("GITHUB_TOKEN", 'password')
+        when:
+        groovyScript.approvePR('pullRequestLink')
+        then:
+        1 * getPipelineMock('usernamePassword.call')([credentialsId: 'kie-ci', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
+        1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
+        1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
+        1 * getPipelineMock("sh")('git config user.name user')
+        1 * getPipelineMock("sh")('gh pr review pullRequestLink --approve') >> { throw new Exception('approve error') }
+        thrown(Exception)
+    }
+
+    def "[githubscm.groovy] approvePR with Credentials"() {
+        setup:
+        groovyScript.getBinding().setVariable("GITHUB_USER", 'user')
+        groovyScript.getBinding().setVariable("GITHUB_TOKEN", 'password')
+        when:
+        groovyScript.approvePR('pullRequestLink', 'credentialsId')
+        then:
+        1 * getPipelineMock('usernamePassword.call')([credentialsId: 'credentialsId', usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN']) >> 'userNamePassword'
+        1 * getPipelineMock("withCredentials")(['userNamePassword'], _ as Closure)
+        1 * getPipelineMock("sh")('git config user.email user@jenkins.kie.apache.org')
+        1 * getPipelineMock("sh")('git config user.name user')
+        1 * getPipelineMock("sh")('gh pr review pullRequestLink --approve"')
     }
 
     def "[githubscm.groovy] tagRepository with buildTag"() {
@@ -1021,13 +1033,6 @@ class GithubScmSpec extends JenkinsPipelineSpecification {
         then:
         1 * getPipelineMock("sh")(['returnStdout': true, 'script': 'git branch --all --contains HEAD']) >> { return '* BXMSPROD-819' }
         result == '* BXMSPROD-819'
-    }
-
-    def "[githubscm.groovy] cleanHubAuth"() {
-        when:
-        groovyScript.cleanHubAuth()
-        then:
-        1 * getPipelineMock("sh")("rm -rf ~/.config/hub")
     }
 
     def "[githubscm.groovy] cleanWorkingTree"() {

--- a/jenkins-pipeline-shared-libraries/vars/githubscm.groovy
+++ b/jenkins-pipeline-shared-libraries/vars/githubscm.groovy
@@ -502,7 +502,6 @@ def updateReleaseBody(String tagName, String credsId = 'kie-ci') {
 *
 * Should use `getLatestTag` method instead which is more flexible
 */
-@Deprecated
 def getPreviousTag(String ignoreTag) {
     String latestTag = sh(returnStdout: true, script: 'git tag --sort=-taggerdate | head -n 1').trim()
     if (latestTag == ignoreTag) {

--- a/jenkins-pipeline-shared-libraries/vars/githubscm.groovy
+++ b/jenkins-pipeline-shared-libraries/vars/githubscm.groovy
@@ -198,10 +198,10 @@ def approvePR(String pullRequestLink, String credentialID = 'kie-ci') {
             setUserConfig("${GITHUB_USER}")
             sh "gh pr review ${pullRequestLink} --approve"
         } catch (Exception e) {
-            println "[ERROR] Can't merge PR ${pullRequestLink} on repo."
+            println "[ERROR] Can't approve PR ${pullRequestLink} on repo."
             throw e
         }
-        println "[INFO] Merged PR '${pullRequestLink}' on repo."
+        println "[INFO] Approved PR '${pullRequestLink}' on repo."
     }
 }
 

--- a/jenkins-pipeline-shared-libraries/vars/githubscm.groovy
+++ b/jenkins-pipeline-shared-libraries/vars/githubscm.groovy
@@ -142,11 +142,9 @@ def squashCommits(String baseBranch, String newCommitMsg) {
 }
 
 def forkRepo(String credentialID = 'kie-ci') {
-    cleanHubAuth()
     withCredentials([usernamePassword(credentialsId: credentialID, usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
         setUserConfig("${GITHUB_USER}")
-        sh 'git config hub.protocol https'
-        sh 'hub fork --remote-name=origin'
+        sh 'gh repo fork --remote-name=origin'
         sh 'git remote -v'
     }
 }
@@ -154,7 +152,7 @@ def forkRepo(String credentialID = 'kie-ci') {
 def createPR(String pullRequestTitle, String pullRequestBody = '', String targetBranch = 'main', String credentialID = 'kie-ci') {
     def pullRequestLink
     try {
-        pullRequestLink = executeHub("hub pull-request -m '${pullRequestTitle}' -m '${pullRequestBody}' -b '${targetBranch}'", credentialID)
+        pullRequestLink = executeGHCli("gh pr create -t '${pullRequestTitle}' -b '${pullRequestBody}' -B '${targetBranch}'", credentialID)
     } catch (Exception e) {
         println "[ERROR] Unable to create PR. Please make sure the targetBranch ${targetBranch} is correct."
         throw e
@@ -166,7 +164,7 @@ def createPR(String pullRequestTitle, String pullRequestBody = '', String target
 def createPrAsDraft(String pullRequestTitle, String pullRequestBody = '', String targetBranch = 'main', String credentialID = 'kie-ci') {
     def pullRequestLink
     try {
-        pullRequestLink = executeHub("hub pull-request -d -m '${pullRequestTitle}' -m '${pullRequestBody}' -b '${targetBranch}'", credentialID)
+        pullRequestLink = executeGHCli("gh pr create -d -t '${pullRequestTitle}' -b '${pullRequestBody}' -B '${targetBranch}'", credentialID)
     } catch (Exception e) {
         println "[ERROR] Unable to create Draft PR. Please make sure the targetBranch ${targetBranch} is correct."
         throw e
@@ -178,7 +176,7 @@ def createPrAsDraft(String pullRequestTitle, String pullRequestBody = '', String
 def createPRWithLabels(String pullRequestTitle, String pullRequestBody = '', String targetBranch = 'main', String[] labels, String credentialID = 'kie-ci') {
     def pullRequestLink
     try {
-        pullRequestLink = executeHub("hub pull-request -m '${pullRequestTitle }' -m '${pullRequestBody }' -b '${targetBranch }' -l ${labels.collect { it -> "'${it }'" }.join(',')}", credentialID)
+        pullRequestLink = executeGHCli("gh pr create -t '${pullRequestTitle }' -b '${pullRequestBody }' -B '${targetBranch }' -l ${labels.collect { it -> "'${it }'" }.join(',')}", credentialID)
     } catch (Exception e) {
         println "[ERROR] Unable to create PR. Please make sure the targetBranch ${targetBranch} is correct."
         throw e
@@ -187,20 +185,31 @@ def createPRWithLabels(String pullRequestTitle, String pullRequestBody = '', Str
     return pullRequestLink
 }
 
-def executeHub(String hubCommand, String credentialID = 'kie-ci') {
-    cleanHubAuth()
+def executeGHCli(String command, String credentialID = 'kie-ci') {
     withCredentials([usernamePassword(credentialsId: credentialID, usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
         setUserConfig("${GITHUB_USER}")
-        return sh(returnStdout: true, script: hubCommand).trim()
+        return sh(returnStdout: true, script: command).trim()
+    }
+}
+
+def approvePR(String pullRequestLink, String credentialID = 'kie-ci') {
+    withCredentials([usernamePassword(credentialsId: credentialID, usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
+        try {
+            setUserConfig("${GITHUB_USER}")
+            sh "gh pr review ${pullRequestLink} --approve"
+        } catch (Exception e) {
+            println "[ERROR] Can't merge PR ${pullRequestLink} on repo."
+            throw e
+        }
+        println "[INFO] Merged PR '${pullRequestLink}' on repo."
     }
 }
 
 def mergePR(String pullRequestLink, String credentialID = 'kie-ci') {
-    cleanHubAuth()
     withCredentials([usernamePassword(credentialsId: credentialID, usernameVariable: 'GITHUB_USER', passwordVariable: 'GITHUB_TOKEN')]) {
         try {
             setUserConfig("${GITHUB_USER}")
-            sh "hub merge ${pullRequestLink}"
+            sh "gh pr merge --admin --rebase --delete-branch ${pullRequestLink}"
         } catch (Exception e) {
             println "[ERROR] Can't merge PR ${pullRequestLink} on repo."
             throw e
@@ -443,10 +452,6 @@ def getForkedProjectName(String group, String repository, String owner, String c
         }
     }
     return result
-}
-
-def cleanHubAuth() {
-    sh 'rm -rf ~/.config/hub'
 }
 
 def cleanWorkingTree() {


### PR DESCRIPTION
ISSUE: https://github.com/apache/incubator-kie-issues/issues/768

This PR replace the hub cli commands with Github CLI commands