### PR TITLE
kie-kogito-serverless-operator-360: Nightly deploy job fails

### DIFF
--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -93,7 +93,7 @@ RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | b
   sudo update-alternatives --install /usr/local/bin/node node $(which node) 1 && \
   sudo update-alternatives --install /usr/local/bin/npm npm $(which npm) 1
   
-RUN wget https://go.dev/dl/go1.19.10.linux-amd64.tar.gz -P /tmp && \
+RUN wget https://go.dev/dl/go1.21.6.linux-amd64.tar.gz -P /tmp && \
   sudo mkdir /opt/golang && \
   sudo tar -C /opt/golang -xzf /tmp/go*.tar.gz && \
   sudo chown -R nonrootuser:nonrootuser /opt/golang/go && \


### PR DESCRIPTION
Failures are caused by missing golang upgrade on CI environment.

This PR, hopefully, updates it for the CI nodes. Please do let me know if I missed some spots.

cc @rodrigonull @ricardozanini we need to update GO in kogito-operator, otherwise this could break the build there.