### PR TITLE
kie-issues#867: Downgrade Docker to version 24.0.7 to avoid issues with docker-squash cmd

### DIFF
--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -6,6 +6,7 @@ ARG SDKMAN_JAVA="17.0.8-tem"
 ARG SDKMAN_MAVEN="3.9.3"
 ARG PYTHON_MAJOR_VERSION="3"
 ARG PYTHON_MAJOR_MINOR_VERSION="3.11"
+ARG DOCKER_VERSION="24.0.7"
 
 # set locale to C.UTF-8
 ENV LANG='C.UTF-8'
@@ -61,7 +62,10 @@ RUN groupadd -g 910 nonrootuser && useradd -u 910 -g 910 -s /bin/bash -m nonroot
   echo "nonrootuser ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # Docker
-RUN groupadd docker && \
+RUN wget -O docker.tgz https://download.docker.com/linux/static/stable/x86_64/docker-${DOCKER_VERSION}.tgz  && \
+  tar --extract --file docker.tgz --strip-components 1 --directory /usr/local/bin/ && \
+  rm -rf docker.tgz && \
+  groupadd docker && \
   usermod -aG docker nonrootuser && \
   newgrp docker
 


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-issues/issues/867

Docker-squash command has some incompatibility with new docker version: 25.x.x.

This PR downgrades the Docker version in our base image to 24.0.7 so we can use it until the incompatibility gets fixed.

More info here: https://github.com/goldmann/docker-squash/issues/236