### PR TITLE
kie-issues-777: fix nodes without docker being assigned for docker jobs

### DIFF
--- a/jenkins-pipeline-shared-libraries/vars/util.groovy
+++ b/jenkins-pipeline-shared-libraries/vars/util.groovy
@@ -560,12 +560,12 @@ void waitForDocker() {
  * Method to wrap original label and exclude nodes that were marked as faulty in some of the parent folders.
  * Example usage in agent block: `label util.avoidFaultyNodes('ubuntu')`
  * `FAULTY_NODES` environment variable is inherited down the folder tree and available in jobs.
- * @param label Node label to be used
+ * @param label Node label to be used. If empty, 'ubuntu' will be used as default
  * @return Node label extended with an expression ensuring to exclude nodes marked as faulty.
  */
-String avoidFaultyNodes(String label) {
-    if (label == null || label.isEmpty()) {
-        return avoidFaultyNodes()
+String avoidFaultyNodes(String label = 'ubuntu') {
+    if (label.isEmpty()) {
+        label = 'ubuntu'
     }
     String faultyNodesString = env.FAULTY_NODES
     if((faultyNodesString == null) || faultyNodesString.isEmpty()) {
@@ -573,21 +573,5 @@ String avoidFaultyNodes(String label) {
     }
     String[] faultyNodes = faultyNodesString.split(',')
     String result = "(${label}) && !(${String.join(' || ', faultyNodes)})"
-    return result.toString()
-}
-
-/**
- * Method to exclude nodes that were marked as faulty in some of the parent folders.
- * Example usage in agent block: `label util.avoidFaultyNodes()`
- * `FAULTY_NODES` environment variable is inherited down the folder tree and available in jobs.
- * @return Node label expression ensuring to exclude nodes marked as faulty.
- */
-String avoidFaultyNodes() {
-    String faultyNodesString = env.FAULTY_NODES
-    if((faultyNodesString == null) || faultyNodesString.isEmpty()) {
-        return '!dummyLabel'    // we need to put something here because label without parameter would cause compile error
-    }
-    String[] faultyNodes = faultyNodesString.split(',')
-    String result = "!(${String.join(' || ', faultyNodes)})"
     return result.toString()
 }


### PR DESCRIPTION
default label 'ubuntu' will be used as a base for calling avoidFaultyNodes