### PR TITLE
kie-issues#1002: disable quarkus usage analytics in CI

### DIFF
--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -191,5 +191,9 @@ RUN sudo bash -c "echo \"dash dash/sh boolean false\" | debconf-set-selections"
 RUN sudo bash -c "DEBIAN_FRONTEND=noninteractive dpkg-reconfigure dash"
 # Use bash as default instead of dash (END)
 
+# Disable quarkus usage analytics (BEGIN)
+RUN mkdir ~/.redhat && (echo '{"disabled":true}' > ~/.redhat/io.quarkus.analytics.localconfig)
+# Disable quarkus usage analytics (END)
+
 ENTRYPOINT ["entrypoint.sh"]
 CMD ["bash"]


### PR DESCRIPTION
Works around apache/incubator-kie-issues#1002 in ASF jenkins CI.

A temporary measure to prevent possible unnecessary 10s waits in CI.