### PR TITLE
kie-issues#1151: use wipeWorkspace instead

### DIFF
--- a/dsl/seed/jobs/seed_job_branch.groovy
+++ b/dsl/seed/jobs/seed_job_branch.groovy
@@ -109,7 +109,7 @@ pipelineJob("${GENERATION_BRANCH}/${JOB_NAME}") {
                     }
                     branch('${SEED_BRANCH}')
                     extensions {
-                        wipeOutWorkspace()
+                        wipeWorkspace()
                         cleanBeforeCheckout()
                     }
                 }
@@ -161,7 +161,7 @@ pipelineJob("${GENERATION_BRANCH}/tools/toggle-dsl-triggers") {
                     }
                     branch(Utils.getSeedBranch(this))
                     extensions {
-                        wipeOutWorkspace()
+                        wipeWorkspace()
                         cleanBeforeCheckout()
                     }
                 }

--- a/dsl/seed/jobs/seed_job_main.groovy
+++ b/dsl/seed/jobs/seed_job_main.groovy
@@ -137,7 +137,7 @@ pipelineJob('0-seed-job') {
                     }
                     branch('${SEED_BRANCH}')
                     extensions {
-                        wipeOutWorkspace()
+                        wipeWorkspace()
                         cleanBeforeCheckout()
                     }
                 }

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/KogitoJobTemplate.groovy
@@ -151,7 +151,7 @@ class KogitoJobTemplate {
                             }
                             branch(jobParams.git.branch)
                             extensions {
-                                wipeOutWorkspace()
+                                wipeWorkspace()
                                 cleanBeforeCheckout()
                                 if (jobParams.git.useRelativeTargetDirectory) {
                                     relativeTargetDirectory(repository)
@@ -236,7 +236,7 @@ class KogitoJobTemplate {
                             branch(jobParams.pr.checkout_branch ?: '${sha1}')
 
                             extensions {
-                                wipeOutWorkspace()
+                                wipeWorkspace()
                                 cleanBeforeCheckout()
                                 if (jobParams.git.useRelativeTargetDirectory) {
                                     relativeTargetDirectory(repository)


### PR DESCRIPTION
switching to `wipeWorkspace()` as `wipeOutWorkspace()` fail during DSL job generation. Interestingly both these methods are mentioned in the DSL reference docs for ASF jenkins instance: https://ci-builds.apache.org/plugin/job-dsl/api-viewer/index.html#path/javaposse.jobdsl.dsl.helpers.workflow.WorkflowDefinitionContext.cpsScm-scm-git-extensions