### PR TITLE
kie-issues#872: adjust branch seed

### DIFF
--- a/dsl/seed/jenkinsfiles/Jenkinsfile.seed.branch
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.seed.branch
@@ -276,12 +276,21 @@ def getRepoConfig(String repository, String generationBranch = "${GENERATION_BRA
 
     String buildchainRepo = cfg.buildchain_config?.git?.repository
     if (buildchainRepo) {
-        def buildchainRepoConfig = buildchainRepo == repository ? cfg : getRepoConfig(buildchainRepo, generationBranch)
-        cfg.buildchain_config.git.branch = cfg.buildchain_config.git.branch ?: buildchainRepoConfig.git.branch
+        def buildchainRepoConfig // to hold existing config from repositories section
+        if (all_repos.contains(buildchainRepo)) {
+            if (buildchainRepo == repository) { // it's the repository currently processed
+                buildchainRepoConfig = cfg
+            } else { // it's a different repository from repositories section
+                buildchainRepoConfig = getRepoConfig(buildchainRepo, generationBranch)
+            }
+        }
 
-        cfg.buildchain_config.git.author = cfg.buildchain_config.git.author ?: [:]
-        cfg.buildchain_config.git.author.name = cfg.buildchain_config.author?.name ?: buildchainRepoConfig.git.author.name
-        cfg.buildchain_config.git.author.credentials_id = cfg.buildchain_config.author?.credentials_id ?: buildchainRepoConfig.git.author.credentials_id
+        // below check if either cfg.buildchain_config or resolved buildchainRepoConfig exists and has value, if not resort to default
+        cfg.buildchain_config.git.branch = cfg.buildchain_config?.git?.branch ?: (buildchainRepoConfig?.git?.branch ?: generationBranch)
+        cfg.buildchain_config.git.author = cfg.buildchain_config?.git?.author ?: [:]
+        cfg.buildchain_config.git.author.name = cfg.buildchain_config?.author?.name ?: (buildchainRepoConfig?.git?.author?.name ?: cfg.git.author.name)
+        cfg.buildchain_config.git.author.credentials_id = cfg.buildchain_config?.author?.credentials_id ?: (buildchainRepoConfig?.git?.author?.credentials_id ?: cfg.git.author.credentials_id)
+        cfg.buildchain_config.git.author.token_credentials_id = cfg.buildchain_config?.author?.token_credentials_id ?: (buildchainRepoConfig?.git?.author?.token_credentials_id ?: cfg.git.author.token_credentials_id)
     }
 
     if (scriptUtils.isDebug()) {


### PR DESCRIPTION
Follows-up on 
* apache/incubator-kie-issues#872
* apache/incubator-kie-drools#5863

This change relaxes relation between `buildchain-config` and `repositories` sections of branch.yaml config:
* buildchain-config repository does not need to be in repositories section 