### PR TITLE
kie-issues#1213: configure kogito-ci-build image from dockerhub

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -80,9 +80,9 @@ maven:
     creds_id: TO_DEFINE
 cloud:
   image:
-    registry_credentials: quay_kiegroup_registry_token
-    registry: quay.io
-    namespace: kiegroup
+    registry_credentials: dockerhub_apache_kie_registry_token
+    registry: docker.io
+    namespace: apache
     latest_git_branch: main
 jenkins:
   email_creds_id: KOGITO_CI_NOTIFICATION_EMAILS
@@ -92,7 +92,7 @@ jenkins:
         # At some point, this image will need to be changed when a release branch is created 
         # but we need to make sure the image exists first ... simple tag before setting up the branch ?
         # See https://github.com/kiegroup/kie-issues/issues/551
-        image: quay.io/kiegroup/kogito-ci-build:main-latest
+        image: docker.io/apache/incubator-kie-kogito-ci-build:main-latest
         args: --privileged --group-add docker
   default_tools:
     jdk: jdk_17_latest

--- a/dsl/scripts/pr_check.groovy
+++ b/dsl/scripts/pr_check.groovy
@@ -28,7 +28,7 @@ dockerArgs = [
 ] + dockerGroups.collect { group -> "--group-add ${group}" }
 
 void launch() {
-    String builderImage = 'quay.io/kiegroup/kogito-ci-build:main-latest'
+    String builderImage = 'docker.io/apache/incubator-kie-kogito-ci-build:main-latest'
     sh "docker rmi -f ${builderImage} || true" // Remove before launching
 
     try {


### PR DESCRIPTION
Fixes:
* apache/incubator-kie-issues#1213

Depends on `docker.io/apache/incubator-kie-kogito-ci-build:main-latest` being released first (after #1197 is merged and pipeline execution succeeds).

Part of PR group:
* apache/incubator-kie-kogito-pipelines#1198
* apache/incubator-kie-drools#5952
* apache/incubator-kie-optaplanner#3087