### PR TITLE
kie-issues#1123: fix nightly deploy of examples

### DIFF
--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -73,7 +73,7 @@ build:
       after:
         # In case of deploy, deploy the parent poms only.
         current: |
-          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
+          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.BUILD_MVN_OPTS }} ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
   # - project: kiegroup/kie-jpmml-integration
   #   build-command:
   #     current: |


### PR DESCRIPTION
Adding a follow-up fix after changing deploy procedure.

Kogito-examples has a special way of deploying snapshots in an after stage, it was missing BUILD_MVN_OPTS env property which holds the settings.xml file with server auth configuration.