### PR TITLE
kie-issues#1238: Update Kogito prepare-release Jenkins jobs to trigger nightly and weekly jobs after setting up branches

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -136,6 +136,21 @@ pipeline {
                 }
             }
         }
+
+        // Launch the weekly to deploy all artifacts from the branch
+        stage('Launch the weekly') {
+            when {
+                expression { return params.DEPLOY }
+            }
+            steps {
+                script {
+                    def buildParams = getDefaultBuildParams()
+                    addBooleanParam(buildParams, 'SKIP_TESTS', true)
+                    addBooleanParam(buildParams, 'SKIP_CLOUD_NIGHTLY', true)
+                    build(job: '../other/0-kogito-weekly', wait: false, parameters: buildParams, propagate: false)
+                }
+            }
+        }
     }
     post {
         unsuccessful {

--- a/.ci/jenkins/Jenkinsfile.setup-branch.cloud
+++ b/.ci/jenkins/Jenkinsfile.setup-branch.cloud
@@ -76,6 +76,20 @@ pipeline {
                 }
             }
         }
+
+        // Launch the weekly to deploy all artifacts from the branch
+        stage('Launch the weekly') {
+            when {
+                expression { return params.DEPLOY }
+            }
+            steps {
+                script {
+                    def buildParams = getDefaultBuildParams()
+                    addBooleanParam(buildParams, 'SKIP_TESTS', true)
+                    build(job: '../other/0-kogito-weekly-cloud', wait: false, parameters: buildParams, propagate: false)
+                }
+            }
+        }
     }
     post {
         unsuccessful {


### PR DESCRIPTION
This PR is part of the [#1238](https://github.com/apache/incubator-kie-issues/issues/1238) issue.

It adds a trigger for the Kogito weekly jobs as part of the `setup-branch` Jenkins job execution.