### PR TITLE
kie-issues#1237: stay on x.y.999-SNAPSHOT in release branches

### DIFF
--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -172,19 +172,6 @@ pipeline {
             }
         }
 
-        stage('Setup next snapshot version') {
-            steps {
-                script {
-                    def buildParams = []
-                    addStringParam(buildParams, 'KOGITO_VERSION', util.getNextVersion(getKogitoVersion(), 'micro'))
-                    addStringParam(buildParams, 'DROOLS_VERSION', util.getNextVersion(getDroolsVersion(), 'micro'))
-                    addBooleanParam(buildParams, 'SKIP_CLOUD_SETUP_BRANCH', true)
-
-                    build(job: '../setup-branch/0-setup-branch', wait: false, parameters: buildParams, propagate: false)
-                }
-            }
-        }
-
         stage('Start Cloud release') {
             when {
                 expression { isCloudRelease() }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -240,14 +240,14 @@ String getGitAuthorPushCredsId() {
 }
 
 String getDroolsVersion() {
-    return params.DROOLS_VERSION ?: getVersionFromReleaseBranch(util.calculateTargetReleaseBranch(getBuildBranch(), 7))
+    return params.DROOLS_VERSION ?: getVersionFromReleaseBranch(getBuildBranch())
 }
 
 String getKogitoVersion() {
     return params.KOGITO_VERSION ?: getVersionFromReleaseBranch(getBuildBranch())
 }
 
-String getVersionFromReleaseBranch(String releaseBranch, int microVersion = 0, String suffix = 'SNAPSHOT') {
+String getVersionFromReleaseBranch(String releaseBranch, int microVersion = 999, String suffix = 'SNAPSHOT') {
     String [] versionSplit = releaseBranch.split("\\.")
     if (versionSplit.length == 3
         && versionSplit[0].isNumber()

--- a/.ci/jenkins/Jenkinsfile.setup-branch.cloud
+++ b/.ci/jenkins/Jenkinsfile.setup-branch.cloud
@@ -172,7 +172,7 @@ String getKogitoVersion() {
     return params.KOGITO_VERSION ?: getVersionFromReleaseBranch(getBuildBranch())
 }
 
-String getVersionFromReleaseBranch(String releaseBranch, int microVersion = 0, String suffix = 'SNAPSHOT') {
+String getVersionFromReleaseBranch(String releaseBranch, int microVersion = 999, String suffix = 'SNAPSHOT') {
     String [] versionSplit = releaseBranch.split("\\.")
     if (versionSplit.length == 3
         && versionSplit[0].isNumber()


### PR DESCRIPTION
Part of
* apache/incubator-kie-issues#1237

Adjusts the snapshot version changes to happen only in new branch when branching, not in main.

Ensemble:
* apache/incubator-kie-kogito-pipelines#1201
* apache/incubator-kie-drools#5967
* apache/incubator-kie-optaplanner#3089
* apache/incubator-kie-kogito-runtimes#3527
* apache/incubator-kie-kogito-apps#2059
* apache/incubator-kie-kogito-examples#1925
* apache/incubator-kie-optaplanner-quickstarts#630