### PR TITLE
kie-issues#1255: agent docker config in main pipeline

### DIFF
--- a/.ci/jenkins/config/main.yaml
+++ b/.ci/jenkins/config/main.yaml
@@ -31,3 +31,11 @@ seed:
   jenkinsfile: dsl/seed/jenkinsfiles/Jenkinsfile.seed.branch
 jenkins:
   email_creds_id: KOGITO_CI_NOTIFICATION_EMAILS
+  agent:
+    docker:
+      builder:
+        # At some point, this image will need to be changed when a release branch is created
+        # but we need to make sure the image exists first ... simple tag before setting up the branch ?
+        # See https://github.com/kiegroup/kie-issues/issues/551
+        image: quay.io/kiegroup/kogito-ci-build:main-latest
+        args: --privileged --group-add docker

--- a/dsl/seed/jenkinsfiles/Jenkinsfile.seed.main
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.seed.main
@@ -58,6 +58,8 @@ pipeline {
                         SEED_CONFIG_FILE_GIT_AUTHOR_PUSH_CREDS_ID: readSeedConfig().seed.config_file.git.author.push.credentials_id,
                         SEED_CONFIG_FILE_GIT_BRANCH: "${SEED_CONFIG_FILE_GIT_BRANCH}",
                         SEED_CONFIG_FILE_PATH: "${SEED_CONFIG_FILE_PATH}",
+                        JENKINS_AGENT_DOCKER_BUILDER_IMAGE: readSeedConfig().jenkins.agent.docker.builder.image,
+                        JENKINS_AGENT_DOCKER_BUILDER_ARGS: readSeedConfig().jenkins.agent.docker.builder.args,
                         ALL_BRANCHES: readSeedConfig().git.branches.collect { it.name }.join(','),
                         MAIN_BRANCH_NAME: readSeedConfig().git.branches.find { it.main_branch }?.name,
                     ]
@@ -104,6 +106,8 @@ pipeline {
                             SEED_CONFIG_FILE_GIT_AUTHOR_PUSH_CREDS_ID: branchConfigFileInfo.push_credentials,
                             SEED_CONFIG_FILE_GIT_BRANCH: branchConfigFileInfo.branch,
                             SEED_CONFIG_FILE_PATH: branchConfigFileInfo.filepath,
+                            JENKINS_AGENT_DOCKER_BUILDER_IMAGE: readSeedConfig().jenkins.agent.docker.builder.image,
+                            JENKINS_AGENT_DOCKER_BUILDER_ARGS: readSeedConfig().jenkins.agent.docker.builder.args,
                         ]
                         echo 'Got envProperties for generation'
                         echo "${envProperties}"
@@ -138,6 +142,8 @@ pipeline {
                         SEED_CONFIG_FILE_GIT_BRANCH: "${SEED_CONFIG_FILE_GIT_BRANCH}",
                         SEED_CONFIG_FILE_PATH: "${SEED_CONFIG_FILE_PATH}",
                         JENKINS_EMAIL_CREDS_ID: readSeedConfig().jenkins.email_creds_id,
+                        JENKINS_AGENT_DOCKER_BUILDER_IMAGE: readSeedConfig().jenkins.agent.docker.builder.image,
+                        JENKINS_AGENT_DOCKER_BUILDER_ARGS: readSeedConfig().jenkins.agent.docker.builder.args,
                     ]
                     dir(scriptUtils.getDslSeedFolderAbsolutePath()) {
                         println "[INFO] Generate main seed job with properties ${envProperties}"

--- a/dsl/seed/jobs/root_jobs.groovy
+++ b/dsl/seed/jobs/root_jobs.groovy
@@ -19,7 +19,6 @@
 
 // +++++++++++++++++++++++++++++++++++++++++++ root jobs ++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-import org.kie.jenkins.jobdsl.utils.JobParamsUtils
 import org.kie.jenkins.jobdsl.KogitoConstants
 import org.kie.jenkins.jobdsl.KogitoJobTemplate
 import org.kie.jenkins.jobdsl.Utils
@@ -38,7 +37,6 @@ def jobParams = [
     env: [:],
     jenkinsfile: 'dsl/seed/jenkinsfiles/Jenkinsfile.release.prepare',
 ]
-JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParams)
 
 KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
     parameters {
@@ -68,6 +66,9 @@ KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
         env('SEED_BRANCH', Utils.getSeedBranch(this))
         env('SEED_CREDENTIALS_ID', Utils.getSeedAuthorCredsId(this))
         env('SEED_PUSH_CREDENTIALS_ID', Utils.getSeedAuthorPushCredsId(this))
+
+        env('AGENT_DOCKER_BUILDER_IMAGE', Utils.getJenkinsAgentDockerImage(this, 'builder'))
+        env('AGENT_DOCKER_BUILDER_ARGS',  Utils.getJenkinsAgentDockerArgs(this, 'builder'))
     }
 }
 
@@ -85,7 +86,6 @@ def jobParamsRemove = [
     env: [:],
     jenkinsfile: 'dsl/seed/jenkinsfiles/Jenkinsfile.remove.branches',
 ]
-JobParamsUtils.setupJobParamsAgentDockerBuilderImageConfiguration(this, jobParamsRemove)
 
 List nonMainBranches = ALL_BRANCHES.split(',').findAll { it != MAIN_BRANCH_NAME }
 if (nonMainBranches) {
@@ -103,6 +103,9 @@ if (nonMainBranches) {
             env('GIT_AUTHOR_PUSH_CREDENTIALS_ID', "${SEED_CONFIG_FILE_GIT_AUTHOR_PUSH_CREDS_ID}")
             env('GIT_BRANCH_TO_BUILD', "${SEED_CONFIG_FILE_GIT_BRANCH}")
             env('CONFIG_FILE_PATH', "${SEED_CONFIG_FILE_PATH}")
+
+            env('AGENT_DOCKER_BUILDER_IMAGE', Utils.getJenkinsAgentDockerImage(this, 'builder'))
+            env('AGENT_DOCKER_BUILDER_ARGS',  Utils.getJenkinsAgentDockerArgs(this, 'builder'))
         }
     }
 } else {

--- a/dsl/seed/jobs/seed_job_branch.groovy
+++ b/dsl/seed/jobs/seed_job_branch.groovy
@@ -150,8 +150,8 @@ pipelineJob("${GENERATION_BRANCH}/tools/toggle-dsl-triggers") {
 
         env('JENKINS_EMAIL_CREDS_ID', Utils.getJenkinsEmailCredsId(this))
 
-        env('AGENT_DOCKER_BUILDER_IMAGE', Utils.getJenkinsAgentDockerImage(script, 'builder'))
-        env('AGENT_DOCKER_BUILDER_ARGS',  Utils.getJenkinsAgentDockerArgs(script, 'builder'))
+        env('AGENT_DOCKER_BUILDER_IMAGE', Utils.getJenkinsAgentDockerImage(this, 'builder'))
+        env('AGENT_DOCKER_BUILDER_ARGS',  Utils.getJenkinsAgentDockerArgs(this, 'builder'))
     }
 
     definition {

--- a/dsl/seed/src/test/groovy/org/kie/jenkins/jobdsl/JobScriptsSpec.groovy
+++ b/dsl/seed/src/test/groovy/org/kie/jenkins/jobdsl/JobScriptsSpec.groovy
@@ -83,6 +83,8 @@ class JobScriptsSpec extends Specification {
         envVars.put('SEED_CONFIG_FILE_GIT_AUTHOR_PUSH_CREDS_ID', 'SEED_CONFIG_FILE_GIT_AUTHOR_PUSH_CREDS_ID')
         envVars.put('SEED_CONFIG_FILE_GIT_BRANCH', 'SEED_CONFIG_FILE_GIT_BRANCH')
         envVars.put('SEED_CONFIG_FILE_PATH', 'SEED_CONFIG_FILE_PATH')
+        envVars.put('JENKINS_AGENT_DOCKER_BUILDER_IMAGE', 'JENKINS_AGENT_DOCKER_BUILDER_IMAGE')
+        envVars.put('JENKINS_AGENT_DOCKER_BUILDER_ARGS', 'JENKINS_AGENT_DOCKER_BUILDER_ARGS')
 
         envVars.put('GIT_JENKINS_CONFIG_PATH', 'GIT_JENKINS_CONFIG_PATH')
         JobManagement jm = new JenkinsJobManagement(System.out, envVars, new File('.'))


### PR DESCRIPTION
To properly fix
* apache/incubator-kie-issues#1255

Adding jenkins agent docker configuration to .ci/config/main.yaml

Also in:
* apache/incubator-kie-kogito-pipelines#1205
* apache/incubator-kie-drools#5971
* apache/incubator-kie-optaplanner#3094

There are jobs already in main pipeline (either root folder or defined in dsl/seed_job_branch.groovy file), which didn't have access to jenkins agent docker image and args configuration from branch.yaml - because that one is loaded only in Jenkinsfile.seed.branch - which did not make it possible to reference these values already in dsl/seed_job_branch.groovy.

So adding the agent docker configuration into main.yaml and loading already in Jenkinsfile.seed.main, so that all DSL jobs are able to use this value loaded from particular branch (except from the dsl/seed_job_main.groovy which is the actual first entry point into DSL generation and no docker config is needed there as of now).