### PR TITLE
kie-issues#1250: prepare for branch,add gpg and svn configuration

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly.cloud
+++ b/.ci/jenkins/Jenkinsfile.nightly.cloud
@@ -35,13 +35,10 @@ pipeline {
 
         KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
-        IMAGE_NAME_NIGHTLY_SUFFIX = 'nightly'
+        IMAGE_NAME_NIGHTLY_SUFFIX = ''
 
         // Use branch name in nightly tag as we may have parallel main and release branch builds
-        NIGHTLY_TAG = """${getBuildBranch()}-${sh(
-                returnStdout: true,
-                script: 'date -u "+%Y-%m-%d"'
-            ).trim()}"""
+        NIGHTLY_TAG = getBuildBranch()
     }
 
     stages {
@@ -206,7 +203,6 @@ void addImageBuildParams(List buildParams, String tag, String paramsPrefix = def
     addStringParam(buildParams, constructKey(paramsPrefix, 'REGISTRY_CREDENTIALS'), env.IMAGE_REGISTRY_CREDENTIALS)
     addStringParam(buildParams, constructKey(paramsPrefix, 'REGISTRY'), env.IMAGE_REGISTRY)
     addStringParam(buildParams, constructKey(paramsPrefix, 'NAMESPACE'), env.IMAGE_NAMESPACE)
-    addStringParam(buildParams, constructKey(paramsPrefix, 'NAME_SUFFIX'), (extraSuffix ? "${extraSuffix}-" : '') + env.IMAGE_NAME_NIGHTLY_SUFFIX)
     addStringParam(buildParams, constructKey(paramsPrefix, 'TAG'), tag)
 }
 

--- a/.ci/jenkins/Jenkinsfile.release.cloud
+++ b/.ci/jenkins/Jenkinsfile.release.cloud
@@ -33,8 +33,6 @@ pipeline {
         // Some generated env is also defined into ./dsl/jobs.groovy file
 
         KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
-
-        IMAGE_NAME_NIGHTLY_SUFFIX = 'nightly'
     }
 
     stages {
@@ -97,68 +95,58 @@ pipeline {
             }
         }
 
-        stage('Build & Deploy Kogito Serverless Operator') {
-            when {
-                expression { return isServerlessOperatorRelease() }
-            }
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams(getKogitoServerlessOperatorVersion())
-                    addSkipTestsParam(buildParams)
-                    addImageBuildParams(buildParams, getKogitoServerlessOperatorTempTag())
+        // stage('Build & Deploy Kogito Serverless Operator') {
+        //     when {
+        //         expression { return isServerlessOperatorRelease() }
+        //     }
+        //     steps {
+        //         script {
+        //             def buildParams = getDefaultBuildParams(getKogitoServerlessOperatorVersion())
+        //             addSkipTestsParam(buildParams)
+        //             addImageBuildParams(buildParams, getKogitoServerlessOperatorTempTag())
 
-                    buildJob(getDeployJobName(kogitoServerlessOperatorRepo), buildParams)
-                }
-            }
-        }
+        //             buildJob(getDeployJobName(kogitoServerlessOperatorRepo), buildParams)
+        //         }
+        //     }
+        // }
 
-        stage('Promote Kogito Images') {
-            when {
-                expression { return isImagesRelease() && isJobConsideredOk(getDeployJobName(kogitoImagesRepo)) }
-            }
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams(getKogitoImagesVersion())
-                    addDeployBuildUrlParamOrClosure(buildParams, getDeployJobName(kogitoImagesRepo)) {
-                        addImageBuildParams(buildParams, getKogitoImagesTempTag(), false, baseImageParamsPrefix)
-                    }
-                    addImageBuildParams(buildParams, getKogitoImagesFinalTag(), true, promoteImageParamsPrefix)
-                    addBooleanParam(buildParams, 'DEPLOY_WITH_LATEST_TAG', isDeployAsLatest())
+        // stage('Promote Kogito Images') {
+        //     when {
+        //         expression { return isImagesRelease() && isJobConsideredOk(getDeployJobName(kogitoImagesRepo)) }
+        //     }
+        //     steps {
+        //         script {
+        //             def buildParams = getDefaultBuildParams(getKogitoImagesVersion())
+        //             addDeployBuildUrlParamOrClosure(buildParams, getDeployJobName(kogitoImagesRepo)) {
+        //                 addImageBuildParams(buildParams, getKogitoImagesTempTag(), false, baseImageParamsPrefix)
+        //             }
+        //             addImageBuildParams(buildParams, getKogitoImagesFinalTag(), true, promoteImageParamsPrefix)
+        //             addBooleanParam(buildParams, 'DEPLOY_WITH_LATEST_TAG', isDeployAsLatest())
 
-                    buildJob(getPromoteJobName(kogitoImagesRepo), buildParams)
-                }
-            }
-        }
+        //             buildJob(getPromoteJobName(kogitoImagesRepo), buildParams)
+        //         }
+        //     }
+        // }
 
-        stage('Promote Kogito Serverless Operator') {
-            when {
-                expression { return isServerlessOperatorRelease() && isJobConsideredOk(getDeployJobName(kogitoServerlessOperatorRepo)) }
-            }
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams(getKogitoServerlessOperatorVersion())
-                    addDeployBuildUrlParamOrClosure(buildParams, getDeployJobName(kogitoServerlessOperatorRepo))  {
-                        addImageBuildParams(buildParams, getKogitoServerlessOperatorTempTag(), false, baseImageParamsPrefix)
-                    }
+        // stage('Promote Kogito Serverless Operator') {
+        //     when {
+        //         expression { return isServerlessOperatorRelease() && isJobConsideredOk(getDeployJobName(kogitoServerlessOperatorRepo)) }
+        //     }
+        //     steps {
+        //         script {
+        //             def buildParams = getDefaultBuildParams(getKogitoServerlessOperatorVersion())
+        //             addDeployBuildUrlParamOrClosure(buildParams, getDeployJobName(kogitoServerlessOperatorRepo))  {
+        //                 addImageBuildParams(buildParams, getKogitoServerlessOperatorTempTag(), false, baseImageParamsPrefix)
+        //             }
 
-                    // Base image information is given by the deploy URL
-                    addImageBuildParams(buildParams, getKogitoServerlessOperatorFinalTag(), true, promoteImageParamsPrefix)
-                    addBooleanParam(buildParams, 'DEPLOY_WITH_LATEST_TAG', isDeployAsLatest())
+        //             // Base image information is given by the deploy URL
+        //             addImageBuildParams(buildParams, getKogitoServerlessOperatorFinalTag(), true, promoteImageParamsPrefix)
+        //             addBooleanParam(buildParams, 'DEPLOY_WITH_LATEST_TAG', isDeployAsLatest())
 
-                    buildJob(getPromoteJobName(kogitoServerlessOperatorRepo), buildParams)
-                }
-            }
-        }
-
-        stage('Setup next snapshot version') {
-            steps {
-                script {
-                    def buildParams = []
-                    addStringParam(buildParams, 'KOGITO_VERSION', util.getNextVersion(getKogitoVersion(), 'micro'))
-                    build(job: '../setup-branch/0-setup-branch-cloud', wait: false, parameters: buildParams, propagate: false)
-                }
-            }
-        }
+        //             buildJob(getPromoteJobName(kogitoServerlessOperatorRepo), buildParams)
+        //         }
+        //     }
+        // }
     }
     post {
         always {
@@ -365,9 +353,6 @@ void addImageBuildParams(List buildParams, String tag, boolean isFinalImage = fa
     addStringParam(buildParams, constructKey(paramsPrefix, 'REGISTRY_CREDENTIALS'), env.IMAGE_REGISTRY_CREDENTIALS)
     addStringParam(buildParams, constructKey(paramsPrefix, 'REGISTRY'), env.IMAGE_REGISTRY)
     addStringParam(buildParams, constructKey(paramsPrefix, 'NAMESPACE'), env.IMAGE_NAMESPACE)
-    if (!isFinalImage) {
-        addStringParam(buildParams, constructKey(paramsPrefix, 'NAME_SUFFIX'), env.IMAGE_NAME_NIGHTLY_SUFFIX)
-    }
     addStringParam(buildParams, constructKey(paramsPrefix, 'TAG'), tag)
 }
 

--- a/.ci/jenkins/Jenkinsfile.weekly.cloud
+++ b/.ci/jenkins/Jenkinsfile.weekly.cloud
@@ -35,8 +35,6 @@ pipeline {
 
         KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
 
-        IMAGE_NAME_WEEKLY_SUFFIX = 'nightly'
-
         // Use branch name in weekly tag as we may have parallel main and release branch builds
         WEEKLY_TAG = """${getBuildBranch()}-${getCurrentDate()}"""
     }
@@ -207,7 +205,6 @@ void addImageBuildParams(List buildParams, String tag, String paramsPrefix = def
     addStringParam(buildParams, constructKey(paramsPrefix, 'REGISTRY_CREDENTIALS'), env.IMAGE_REGISTRY_CREDENTIALS)
     addStringParam(buildParams, constructKey(paramsPrefix, 'REGISTRY'), env.IMAGE_REGISTRY)
     addStringParam(buildParams, constructKey(paramsPrefix, 'NAMESPACE'), env.IMAGE_NAMESPACE)
-    addStringParam(buildParams, constructKey(paramsPrefix, 'NAME_SUFFIX'), (extraSuffix ? "${extraSuffix}-" : '') + env.IMAGE_NAME_WEEKLY_SUFFIX)
     addStringParam(buildParams, constructKey(paramsPrefix, 'TAG'), tag)
 }
 

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -19,6 +19,8 @@ environments:
     auto_generation: false
     ids:
     - ecosystem
+disable:
+  images-deploy: false
 repositories:
 - name: incubator-kie-kogito-pipelines
   job_display_name: kogito-pipelines
@@ -84,6 +86,14 @@ cloud:
     registry: quay.io
     namespace: kiegroup
     latest_git_branch: main
+release:
+  gpg:
+    sign:
+      key-credentials-id: 'asf-release-gpg-signing-key'
+      passphrase-credentials-id: 'asf-release-gpg-signing-key-passphrase'
+  svn:
+    staging-repository: <TO-BE-DEFINED>
+    credentials-id: <TO-BE-DEFINED>
 jenkins:
   email_creds_id: KOGITO_CI_NOTIFICATION_EMAILS
   agent:

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
@@ -326,8 +326,25 @@ class Utils {
         return getBindingValue(script, 'DISABLE_DEPLOY').toBoolean() || isTestEnvironment(script)
     }
 
+    static boolean isImagesDeployDisabled(def script) {
+        return getBindingValue(script, 'DISABLE_IMAGES_DEPLOY').toBoolean() || isTestEnvironment(script)
+    }
+
     static boolean isPrCheckDisabled(def script) {
         return getBindingValue(script, 'DISABLE_PR_CHECK').toBoolean() || isTestEnvironment(script)
+    }
+
+    static String getReleaseGpgSignKeyCredentialsId(def script) {
+        return getBindingValue(script, 'RELEASE_GPG_SIGN_KEY_CREDENTIALS_ID')
+    }
+    static String getReleaseGpgSignPassphraseCredentialsId(def script) {
+        return getBindingValue(script, 'RELEASE_GPG_SIGN_PASSPHRASE_CREDENTIALS_ID')
+    }
+    static String getReleaseSvnCredentialsId(def script) {
+        return getBindingValue(script, 'RELEASE_SVN_CREDENTIALS_ID')
+    }
+    static String getReleaseSvnStagingRepository(def script) {
+        return getBindingValue(script, 'RELEASE_SVN_STAGING_REPOSITORY')
     }
 
 }

--- a/jenkins-pipeline-shared-libraries/vars/release.groovy
+++ b/jenkins-pipeline-shared-libraries/vars/release.groovy
@@ -1,6 +1,6 @@
 def gpgImportKeyFromFileWithPassword(String gpgKeyCredentialsId, String gpgKeyPasswordCredentialsId) {
     withCredentials([file(credentialsId: gpgKeyCredentialsId, variable: 'SIGNING_KEY')]) {
-        withCredentials([file(credentialsId: gpgKeyPasswordCredentialsId, variable: 'SIGNING_KEY_PASSWORD')]) {
+        withCredentials([string(credentialsId: gpgKeyPasswordCredentialsId, variable: 'SIGNING_KEY_PASSWORD')]) {
             // copy the key to singkey.gpg file in *plain text* so we can import it
             sh """
                 cat $SIGNING_KEY > $WORKSPACE/signkey.gpg
@@ -14,7 +14,7 @@ def gpgImportKeyFromFileWithPassword(String gpgKeyCredentialsId, String gpgKeyPa
 }
 
 def gpgSignFileDetachedSignatureWithPassword(String file, String signatureTarget, String gpgKeyPasswordCredentialsId) {
-    withCredentials([file(credentialsId: gpgKeyPasswordCredentialsId, variable: 'SIGNING_KEY_PASSWORD')]) {
+    withCredentials([string(credentialsId: gpgKeyPasswordCredentialsId, variable: 'SIGNING_KEY_PASSWORD')]) {
         sh "gpg --batch --sign --pinentry-mode=loopback --passphrase \"${SIGNING_KEY_PASSWORD}\" --output ${signatureTarget} --detach-sig ${file}"
     }
 }

--- a/jenkins-pipeline-shared-libraries/vars/release.groovy
+++ b/jenkins-pipeline-shared-libraries/vars/release.groovy
@@ -1,0 +1,28 @@
+def gpgImportKeyFromFileWithPassword(String gpgKeyCredentialsId, String gpgKeyPasswordCredentialsId) {
+    withCredentials([file(credentialsId: gpgKeyCredentialsId, variable: 'SIGNING_KEY')]) {
+        withCredentials([file(credentialsId: gpgKeyPasswordCredentialsId, variable: 'SIGNING_KEY_PASSWORD')]) {
+            // copy the key to singkey.gpg file in *plain text* so we can import it
+            sh """
+                cat $SIGNING_KEY > $WORKSPACE/signkey.gpg
+                # Please do not remove list keys command. When gpg is run for the first time, it may initialize some internals.
+                gpg --list-keys
+                gpg --batch --pinentry-mode=loopback --passphrase \"${SIGNING_KEY_PASSWORD}\" --import signkey.gpg
+                rm $WORKSPACE/signkey.gpg
+            """
+        }
+    }
+}
+
+def gpgSignFileDetachedSignatureWithPassword(String file, String signatureTarget, String gpgKeyPasswordCredentialsId) {
+    withCredentials([file(credentialsId: gpgKeyPasswordCredentialsId, variable: 'SIGNING_KEY_PASSWORD')]) {
+        sh "gpg --batch --sign --pinentry-mode=loopback --passphrase \"${SIGNING_KEY_PASSWORD}\" --output ${signatureTarget} --detach-sig ${file}"
+    }
+}
+
+boolean gpgIsValidDetachedSignature(String file, String signature) {
+    return sh(returnStatus: true, script: "gpg --batch --verify ${signature} ${file}") == 0
+}
+
+def svnUploadFileToRepository(String svnRepository, String svnCredentialsId, String... files) {
+    throw new NotImplementedException("stub");
+}

--- a/jenkins-pipeline-shared-libraries/vars/release.groovy
+++ b/jenkins-pipeline-shared-libraries/vars/release.groovy
@@ -23,6 +23,17 @@ boolean gpgIsValidDetachedSignature(String file, String signature) {
     return sh(returnStatus: true, script: "gpg --batch --verify ${signature} ${file}") == 0
 }
 
-def svnUploadFileToRepository(String svnRepository, String svnCredentialsId, String... files) {
-    throw new NotImplementedException("stub");
+def svnUploadFileToRepository(String svnRepository, String svnCredentialsId, String releaseVersion, String... files) {
+    withCredentials([usernamePassword(credentialsId: svnCredentialsId, usernameVariable: 'ASF_USERNAME', passwordVariable: 'ASF_PASSWORD')]) {
+        sh "svn co --depth=empty ${svnRepository} svn-kie"
+        for (file in files) {
+            sh "cp ${file} svn-kie/${releaseVersion}/"
+        }
+        sh """
+        svn add "svn-kie/${releaseVersion}"
+        cd svn-kie
+        svn ci --non-interactive --no-auth-cache --username ${ASF_USERNAME} --password '${ASF_PASSWORD}' -m "Apache KIE ${releaseVersion} artifacts"
+        rm -rf svn-kie
+        """
+    }
 }


### PR DESCRIPTION
Addresses:
* apache/incubator-kie-issues#1250
* apache/incubator-kie-issues#1251

* Adding release configuration entries for gpg and svn into branch.yaml config. (to drools and optaplanner to come later).
* removing suffix from nightly image name (-nightly) and tag (-yyyymmdd)
* removing operator from the pipeline for now
* removing images promoting
* adding disable: images-deploy configuration option to be set to `true` on release branch.
* Adding release pipeline shared library var with gpg and svn methods