### PR TITLE
NO-ISSUE: Use a fixed version for kogito-ci-build base image

### DIFF
--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -1,4 +1,4 @@
-FROM cruizba/ubuntu-dind:latest
+FROM cruizba/ubuntu-dind:jammy-26.1.4
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
The latest version of `cruizba/ubuntu-dind` has been upgraded to Ubuntu 24.04 which conflicts with some packages we install in the `kogito-ci-build `image. Let's fix the base image version to Ubuntu jammy (22.04) to avoid problems.