### PR TITLE
Disable kogito-serverless-operator pipelines

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -32,8 +32,8 @@ repositories:
   job_display_name: kogito-examples
 - name: incubator-kie-kogito-images
   job_display_name: kogito-images
-- name: incubator-kie-kogito-serverless-operator
-  job_display_name: kogito-serverless-operator
+# - name: incubator-kie-kogito-serverless-operator
+#   job_display_name: kogito-serverless-operator
 - name: incubator-kie-kogito-docs
   job_display_name: kogito-docs
 - name: incubator-kie-docs


### PR DESCRIPTION
Kogito serverless operator code has been moved to KIE tools for the Apache 10 release.

We need to disable the CI pipelines for this project to avoid having images published from these jobs until we have the Apache 10 release and move the code back to the original git repository.