### PR TITLE
[10.0.x] NO-ISSUE: Fix drools version for nightly.quarkus-platform

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly.quarkus-platform
+++ b/.ci/jenkins/Jenkinsfile.nightly.quarkus-platform
@@ -56,7 +56,7 @@ pipeline {
                     dir('optaplanner') {
                         deleteDir()
                         // Get current corresponding branch and if not working, latest tag
-                        String opBranch = getTargetBranch(7)
+                        String opBranch = getGitBranch()
                         try {
                             checkout(githubscm.resolveRepository('incubator-kie-optaplanner', getGitAuthor(), opBranch, false))
                         } catch(err) {

--- a/.ci/jenkins/Jenkinsfile.nightly.quarkus-platform
+++ b/.ci/jenkins/Jenkinsfile.nightly.quarkus-platform
@@ -43,7 +43,7 @@ pipeline {
                 script {
                     dir('drools') {
                         deleteDir()
-                        checkout(githubscm.resolveRepository('incubator-kie-drools', getGitAuthor(), getTargetBranch(7), false))
+                        checkout(githubscm.resolveRepository('incubator-kie-drools', getGitAuthor(), getGitBranch(), false))
                     }
                     dir('kogito-runtimes') {
                         deleteDir()


### PR DESCRIPTION
Review by @pibizza "[REVIEW] [NOT OK] Current status for the kogito 10.x jobs"

```
Red
- quarkus-platform.deploy
The build is consistently failing with the error "ERROR: Couldn't find any
revision to build. Verify the repository and branch configuration for this
job."
https://ci-builds.apache.org/job/KIE/job/kogito/job/10.0.x/job/nightly/job/quarkus-platform.deploy/9/
```

```
09:28:40  [INFO] Resolving Repository https://github.com/apache/incubator-kie-drools:17.0.x. CredentialsID: kie-ci
```
It tries to check out branch `17.0.x`. 

`getTargetBranch(7)` means adds the major version `7`, which is probably an old approach when kogito version was `1` and drools version was `8`. Now, all projects aligns to `10.0.x`.