### PR TITLE
NO-ISSUE: Fix drools version for nightly.quarkus-platform

### DIFF
--- a/.ci/jenkins/Jenkinsfile.nightly.quarkus-platform
+++ b/.ci/jenkins/Jenkinsfile.nightly.quarkus-platform
@@ -43,7 +43,7 @@ pipeline {
                 script {
                     dir('drools') {
                         deleteDir()
-                        checkout(githubscm.resolveRepository('incubator-kie-drools', getGitAuthor(), getTargetBranch(7), false))
+                        checkout(githubscm.resolveRepository('incubator-kie-drools', getGitAuthor(), getGitBranch(), false))
                     }
                     dir('kogito-runtimes') {
                         deleteDir()
@@ -56,7 +56,7 @@ pipeline {
                     dir('optaplanner') {
                         deleteDir()
                         // Get current corresponding branch and if not working, latest tag
-                        String opBranch = getTargetBranch(7)
+                        String opBranch = getGitBranch()
                         try {
                             checkout(githubscm.resolveRepository('incubator-kie-optaplanner', getGitAuthor(), opBranch, false))
                         } catch(err) {


### PR DESCRIPTION
- Fix optaplanner branch version, too

This is a forward-port PR of https://github.com/apache/incubator-kie-kogito-pipelines/pull/1229 for main branch