### PR TITLE
Remove org.jbpm group gav from the cache

### DIFF
--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -59,6 +59,8 @@ runs:
         # Workaround taken from https://github.com/actions/toolkit/issues/713#issuecomment-850321461
         path: |
           ~/.m2/repository/*/*
+          !~/.m2/repository/org/jbpm
+          !~/.m2/repository/org/apache/kie/sonataflow
           !~/.m2/repository/org/kie
           !~/.m2/repository/org/drools
           !~/.m2/repository/org/optaplanner

--- a/.ci/actions/maven/action.yml
+++ b/.ci/actions/maven/action.yml
@@ -60,7 +60,7 @@ runs:
         path: |
           ~/.m2/repository/*/*
           !~/.m2/repository/org/jbpm
-          !~/.m2/repository/org/apache/kie/sonataflow
+          !~/.m2/repository/org/apache/kie
           !~/.m2/repository/org/kie
           !~/.m2/repository/org/drools
           !~/.m2/repository/org/optaplanner


### PR DESCRIPTION
this is removing snapshots to the cache. After merge this, caches need to be cleanedup.