### PR TITLE
[10.0.x] NO-ISSUE: Kogito Images release job fixes

### DIFF
--- a/.ci/jenkins/Jenkinsfile.release.cloud
+++ b/.ci/jenkins/Jenkinsfile.release.cloud
@@ -287,8 +287,8 @@ void addImageBuildParams(List buildParams, String tag, boolean isFinalImage = fa
     addBooleanParam(buildParams, constructKey(paramsPrefix, 'USE_OPENSHIFT_REGISTRY'), false)
     addStringParam(buildParams, constructKey(paramsPrefix, 'REGISTRY_USER_CREDENTIALS_ID'), '')
     addStringParam(buildParams, constructKey(paramsPrefix, 'REGISTRY_TOKEN_CREDENTIALS_ID'), '')
-    addStringParam(buildParams, constructKey(paramsPrefix, 'REGISTRY'), '')
-    addStringParam(buildParams, constructKey(paramsPrefix, 'NAMESPACE'), '')
+    addStringParam(buildParams, constructKey(paramsPrefix, 'REGISTRY'), env.IMAGE_REGISTRY)
+    addStringParam(buildParams, constructKey(paramsPrefix, 'NAMESPACE'), env.IMAGE_NAMESPACE)
     addStringParam(buildParams, constructKey(paramsPrefix, 'TAG'), tag)
 }
 

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -305,6 +305,9 @@ void setupReleaseCloudJob() {
     jobParams.env.putAll([
         JENKINS_EMAIL_CREDS_ID: "${JENKINS_EMAIL_CREDS_ID}",
 
+        IMAGE_REGISTRY: "${CLOUD_IMAGE_REGISTRY}",
+        IMAGE_NAMESPACE: "${CLOUD_IMAGE_NAMESPACE}",
+
         GIT_BRANCH_NAME: "${GIT_BRANCH}",
         GIT_AUTHOR: "${GIT_AUTHOR_NAME}",
     ])

--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -1,4 +1,4 @@
-FROM cruizba/ubuntu-dind:jammy-26.1.4
+FROM cruizba/ubuntu-dind:jammy-26.1.4:q
 
 SHELL ["/bin/bash", "-c"]
 
@@ -55,6 +55,7 @@ libasound2 \
 # kogito-images (BEGIN)
 jq \
 skopeo \
+subversion \
 # kogito-images (END)
 && apt clean
 

--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -1,4 +1,4 @@
-FROM cruizba/ubuntu-dind:jammy-26.1.4:q
+FROM cruizba/ubuntu-dind:jammy-26.1.4
 
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
This PR adds some missing env vars required for the Kogito images release job and it also installs subversion in the image we use for the CI jobs.