### PR TITLE
kie-issues#2618: Remove Kogito Images jobs

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -30,8 +30,6 @@ repositories:
   job_display_name: kogito-apps
 - name: incubator-kie-kogito-examples
   job_display_name: kogito-examples
-- name: incubator-kie-kogito-images
-  job_display_name: kogito-images
 # - name: incubator-kie-kogito-serverless-operator
 #   job_display_name: kogito-serverless-operator
 - name: incubator-kie-kogito-docs


### PR DESCRIPTION
Closes: https://github.com/apache/incubator-kie-tools/issues/2618

Kogito images has been moved to KIE tools repository. This PR removes the kogito images jobs that are part of the kogito Jenkins folder.