### PR TITLE
NO-ISSUE: Add svn package to the kogito-ci-build image

### DIFF
--- a/apache-nodes/Dockerfile.kogito-ci-build
+++ b/apache-nodes/Dockerfile.kogito-ci-build
@@ -55,6 +55,7 @@ libasound2 \
 # kogito-images (BEGIN)
 jq \
 skopeo \
+subversion \
 # kogito-images (END)
 && apt clean
 


### PR DESCRIPTION
This PR adds the subversion package to the kogito-ci-build image that we use to build and publish release artifacts to the Apache SVN repositories.