### PR TITLE
[10.0.x] CI duplicate maven configuration entries

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -63,7 +63,11 @@ buildchain_config:
     file_path: .ci/pull-request-config.yaml
     token_credentials_id: kie-ci3-token
 maven:
-  settings_file_id: kie-release-settings
+  settings:
+    nightly:
+      config_file_id: kie-nightly-settings
+    release:
+      config_file_id: kie-release-settings
   nexus:
     release_url: TO_DEFINE
     release_repository: TO_DEFINE
@@ -72,8 +76,12 @@ maven:
     build_promotion_profile_id: TO_DEFINE
   artifacts_repository: ''
   artifacts_upload_repository:
-    url: https://repository.apache.org/content/repositories/snapshots
-    creds_id: apache-nexus-kie-deploy-credentials
+    nightly:
+      url: https://repository.apache.org/content/repositories/snapshots
+      creds_id: apache-nexus-kie-deploy-credentials
+    release:
+      url: https://repository.apache.org/service/local/staging/deploy/maven2
+      creds_id: jenkins-deploy-to-nexus-staging
   quarkus_platform_repository:
     url: TO_DEFINE
     creds_id: TO_DEFINE

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -213,7 +213,7 @@ void setupWeeklyCloudJob() {
         IMAGE_NAMESPACE: "${CLOUD_IMAGE_NAMESPACE}",
         BRANCH_FOR_LATEST: "${CLOUD_IMAGE_LATEST_GIT_BRANCH}",
 
-        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        MAVEN_SETTINGS_CONFIG_FILE_ID: Utils.getMavenSettingsConfigFileId(this, JobType.NIGHTLY.name),
         ARTIFACTS_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {
@@ -245,7 +245,7 @@ void setupNightlyCloudJob() {
         IMAGE_NAMESPACE: "${CLOUD_IMAGE_NAMESPACE}",
         BRANCH_FOR_LATEST: "${CLOUD_IMAGE_LATEST_GIT_BRANCH}",
 
-        MAVEN_SETTINGS_CONFIG_FILE_ID: "${MAVEN_SETTINGS_FILE_ID}",
+        MAVEN_SETTINGS_CONFIG_FILE_ID: Utils.getMavenSettingsConfigFileId(this, JobType.NIGHTLY.name),
         ARTIFACTS_REPOSITORY: "${MAVEN_ARTIFACTS_REPOSITORY}",
     ])
     KogitoJobTemplate.createPipelineJob(this, jobParams)?.with {

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/Utils.groovy
@@ -258,12 +258,12 @@ class Utils {
         return getBindingValue(script, 'BUILDCHAIN_CONFIG_GIT_TOKEN_CREDENTIALS_ID')
     }
 
-    static String getMavenArtifactsUploadRepositoryUrl(def script) {
-        return getBindingValue(script, 'MAVEN_ARTIFACTS_UPLOAD_REPOSITORY_URL')
+    static String getMavenArtifactsUploadRepositoryUrl(def script, String jobType = "nightly") {
+        return getBindingValue(script, "MAVEN_ARTIFACTS_UPLOAD_REPOSITORY_${jobType.toUpperCase()}_URL")
     }
 
-    static String getMavenArtifactsUploadRepositoryCredentialsId(def script) {
-        return getBindingValue(script, 'MAVEN_ARTIFACTS_UPLOAD_REPOSITORY_CREDS_ID')
+    static String getMavenArtifactsUploadRepositoryCredentialsId(def script, String jobType = "nightly") {
+        return getBindingValue(script, "MAVEN_ARTIFACTS_UPLOAD_REPOSITORY_${jobType.toUpperCase()}_CREDS_ID")
     }
 
     static String getMavenQuarkusPlatformRepositoryUrl(def script) {
@@ -272,6 +272,10 @@ class Utils {
 
     static String getMavenQuarkusPlatformRepositoryCredentialsId(def script) {
         return getBindingValue(script, 'MAVEN_QUARKUS_PLATFORM_REPOSITORY_CREDS_ID')
+    }
+
+    static String getMavenSettingsConfigFileId(def script, String jobType = 'nightly') {
+        return getBindingValue(script, "MAVEN_SETTINGS_${jobType.toUpperCase()}_CONFIG_FILE_ID")
     }
 
     static String getJenkinsAgentDockerImage(def script, String imageId) {

--- a/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/utils/JobParamsUtils.groovy
+++ b/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/utils/JobParamsUtils.groovy
@@ -186,11 +186,11 @@ class JobParamsUtils {
         addJobParamsEnvIfNotExisting(script, jobParams, 'INTEGRATION_BRANCH_CURRENT', "${Utils.getGenerationBranch(script)}-integration-${envName}")
     }
 
-    static def setupJobParamsDeployConfiguration(def script, def jobParams) {
+    static def setupJobParamsDeployConfiguration(def script, JobType jobType, def jobParams) {
         jobParams.env = jobParams.env ?: [:]
         jobParams.env.put('ENABLE_DEPLOY', String.valueOf(!Utils.isDeployDisabled(script)))
         addJobParamsEnvIfNotExisting(script, jobParams, 'MAVEN_DEPLOY_REPOSITORY', Utils.getMavenArtifactsUploadRepositoryUrl(script))
-        addJobParamsEnvIfNotExisting(script, jobParams, 'MAVEN_DEPLOY_REPOSITORY_CREDS_ID', Utils.getMavenArtifactsUploadRepositoryCredentialsId(script))
+        addJobParamsEnvIfNotExisting(script, jobParams, 'MAVEN_DEPLOY_REPOSITORY_CREDS_ID', Utils.getMavenArtifactsUploadRepositoryCredentialsId(script, jobType.name))
     }
 
     static def setupJobParamsAgentDockerBuilderImageConfiguration(def script, def jobParams) {


### PR DESCRIPTION
Adjusting branch.yaml configuration to split maven related configurations for nightly and release.

Part of ensemble:

- apache/incubator-kie-kogito-pipelines#1254
- apache/incubator-kie-drools#6130
- apache/incubator-kie-optaplanner#3133
- apache/incubator-kie-optaplanner-quickstarts#634
- apache/incubator-kie-kogito-runtimes#3737
- apache/incubator-kie-kogito-apps#2119
- apache/incubator-kie-kogito-examples#2025

The scope of changes:

- maven settings.xml reference (config file id pointing at pre-defined config file in jenkins)
- artifacts upload repository
  - url - mostly informational, should not be needed for deploy itself (inheriting that configuration from apache parent)
  - credentials-id - the important part, allowing to configure different credentials for nightly and release.

Notes:
- in some places the configuration variants denoted as nightly are used in other places too (e.g. setup-branch).

Follow-up:

- after this gets merged, incubator-kie-kogito-pipelines PR needs to be backported also into branches:
  - seed-drools-10.0.x
  - seed-kogito-10.0.x
  - seed-optaplanner-10.0.x 