### PR TITLE
[10.0.x] fix maven settings env var in buildchain

### DIFF
--- a/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
@@ -16,8 +16,8 @@ mavenDeployLocalDir = env.MAVEN_DEPLOY_LOCAL_DIR ?: ''
 
 buildChainType = env.BUILDCHAIN_TYPE?.trim() ?: 'cross_pr'
 buildChainProject = env.BUILDCHAIN_PROJECT?.trim()
-defaultSettingsXmlId = isPRBuildChainType() || isFDBBuildChainType() ? 'kie-pr-settings' : 'kie-release-settings'
-settingsXmlId = env.MAVEN_SETTINGS_FILE_ID ?: defaultSettingsXmlId
+defaultSettingsXmlId = isPRBuildChainType() || isFDBBuildChainType() ? 'kie-pr-settings' : 'kie-nightly-settings'
+settingsXmlId = env.MAVEN_SETTINGS_CONFIG_FILE_ID ?: defaultSettingsXmlId
 
 enableSonarCloudAnalysis = env.ENABLE_SONARCLOUD ? env.ENABLE_SONARCLOUD.toBoolean() : false
 downstreamBuild = env.DOWNSTREAM_BUILD ? env.DOWNSTREAM_BUILD.toBoolean() : false


### PR DESCRIPTION
Wrap up after:
- #1258 

Renaming Jenkinsfile.buildchain `MAVEN_SETTINGS_FILE_ID` to `MAVEN_SETTINGS_CONFIG_FILE_ID` as a leftover.