### PR TITLE
kie-issues#1750: Try Maven Central before hitting `repository.apache.org`

### DIFF
--- a/.ci/jenkins/tests/pom.xml
+++ b/.ci/jenkins/tests/pom.xml
@@ -29,6 +29,14 @@
 
     <repositories>
         <repository>
+            <id>central</id>
+            <name>Central Repository</name>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+        </repository>
+        <repository>
             <id>apache-public-repository-group</id>
             <name>Apache Public Repository Group</name>
             <url>https://repository.apache.org/content/groups/public/</url>


### PR DESCRIPTION
Part of https://github.com/apache/incubator-kie-issues/issues/1750

## What changes were proposed in this pull request?

[CI build](https://github.com/apache/incubator-kie-kogito-pipelines/actions/runs/12029669000/job/33535438954#step:4:58) is trying to download non-Apache artifacts from `repository.apache.org`:

```
[INFO] Downloading from apache-public-repository-group: https://repository.apache.org/content/groups/public/org/codehaus/groovy/groovy-all/2.5.19/groovy-all-2.5.19.pom
[INFO] Downloading from jenkins-releases: https://repo.jenkins-ci.org/releases/org/codehaus/groovy/groovy-all/2.5.19/groovy-all-2.5.19.pom
[INFO] Downloading from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/org/codehaus/groovy/groovy-all/2.5.19/groovy-all-2.5.19.pom
[INFO] Downloaded from repo.jenkins-ci.org: https://repo.jenkins-ci.org/public/org/codehaus/groovy/groovy-all/2.5.19/groovy-all-2.5.19.pom (25 kB at 309 kB/s)
```

Repositories defined in `pom.xml` have [higher precedence](https://maven.apache.org/guides/mini/guide-multiple-repositories.html#Repository_Order) than `central` repo inherited from [super POM](https://maven.apache.org/pom.html#The_Super_POM).

See https://infra.apache.org/infra-ban.html ("Excessive 404") for why this is a problem.

This change explicitly adds `central` as first repository.

(related change: https://github.com/apache/incubator-kie-kogito-runtimes/pull/3816)