### PR TITLE
NO-ISSUE: remove archive-artifacts from bc config files

### DIFF
--- a/.ci/buildchain-config-pr-cdb.yaml
+++ b/.ci/buildchain-config-pr-cdb.yaml
@@ -63,11 +63,6 @@ build:
         mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
       downstream: |
         mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_DOWNSTREAM }}
-    archive-artifacts:
-      path: |
-        **/*.log
-        **/cypress/screenshots/**
-        **/cypress/videos/**
 
   - project: apache/incubator-kie-kogito-examples
     build-command:

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -60,11 +60,6 @@ build:
         mvn dependency:tree clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
       upstream: |
         mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
-    archive-artifacts:
-      path: |
-        **/*.log
-        **/cypress/screenshots/**
-        **/cypress/videos/**
 
   - project: apache/incubator-kie-kogito-examples
     build-command:


### PR DESCRIPTION
Removing the archive-artifacts setting from buildchain config for kogito-apps, this started failing with:
```
2025-02-04T09:07:36.4815525Z Create Artifact Container - Error is not retryable
2025-02-04T09:07:36.4816325Z ##### Begin Diagnostic HTTP information #####
2025-02-04T09:07:36.4816853Z Status Code: 400
2025-02-04T09:07:36.4817120Z Status Message: Bad Request
2025-02-04T09:07:36.4817354Z Header Information: {
2025-02-04T09:07:36.4817570Z   "content-length": "268",
2025-02-04T09:07:36.4817850Z   "content-type": "application/json; charset=utf-8",
2025-02-04T09:07:36.4818173Z   "date": "Tue, 04 Feb 2025 09:07:36 GMT",
2025-02-04T09:07:36.4818646Z   "server": "Kestrel",
2025-02-04T09:07:36.4818887Z   "cache-control": "no-store,no-cache",
2025-02-04T09:07:36.4819163Z   "pragma": "no-cache",
2025-02-04T09:07:36.4819482Z   "strict-transport-security": "max-age=2592000",
2025-02-04T09:07:36.4820117Z   "x-tfs-processid": "cbec92e7-db37-4d2f-bbbf-0d0207a48e5e",
2025-02-04T09:07:36.4820782Z   "activityid": "971eb4fa-c2bf-4c87-ba11-e37d5a94cf3c",
2025-02-04T09:07:36.4821758Z   "x-tfs-session": "971eb4fa-c2bf-4c87-ba11-e37d5a94cf3c",
2025-02-04T09:07:36.4822253Z   "x-vss-e2eid": "971eb4fa-c2bf-4c87-ba11-e37d5a94cf3c",
2025-02-04T09:07:36.4822662Z   "x-vss-senderdeploymentid": "193695a0-0dcd-ade4-f810-b10ad24a9829",
2025-02-04T09:07:36.4823032Z   "x-frame-options": "SAMEORIGIN"
2025-02-04T09:07:36.4823265Z }
2025-02-04T09:07:36.4823460Z ###### End Diagnostic HTTP information ######
2025-02-04T09:07:36.4823817Z ##### Begin Diagnostic HTTP information #####
2025-02-04T09:07:36.4824230Z Status Code: 400
2025-02-04T09:07:36.4824577Z Status Message: Bad Request
2025-02-04T09:07:36.4825060Z Header Information: {
2025-02-04T09:07:36.4825279Z   "content-length": "268",
2025-02-04T09:07:36.4825549Z   "content-type": "application/json; charset=utf-8",
2025-02-04T09:07:36.4825855Z   "date": "Tue, 04 Feb 2025 09:07:36 GMT",
2025-02-04T09:07:36.4826110Z   "server": "Kestrel",
2025-02-04T09:07:36.4826334Z   "cache-control": "no-store,no-cache",
2025-02-04T09:07:36.4826599Z   "pragma": "no-cache",
2025-02-04T09:07:36.4826854Z   "strict-transport-security": "max-age=2592000",
2025-02-04T09:07:36.4827469Z   "x-tfs-processid": "cbec92e7-db37-4d2f-bbbf-0d0207a48e5e",
2025-02-04T09:07:36.4828086Z   "activityid": "971eb4fa-c2bf-4c87-ba11-e37d5a94cf3c",
2025-02-04T09:07:36.4828811Z   "x-tfs-session": "971eb4fa-c2bf-4c87-ba11-e37d5a94cf3c",
2025-02-04T09:07:36.4829161Z   "x-vss-e2eid": "971eb4fa-c2bf-4c87-ba11-e37d5a94cf3c",
2025-02-04T09:07:36.4829544Z   "x-vss-senderdeploymentid": "193695a0-0dcd-ade4-f810-b10ad24a9829",
2025-02-04T09:07:36.4829906Z   "x-frame-options": "SAMEORIGIN"
2025-02-04T09:07:36.4830141Z }
2025-02-04T09:07:36.4830333Z ###### End Diagnostic HTTP information ######
2025-02-04T09:07:36.4832374Z [INFO] Failure in uploading artifacts for one or more nodes: Error: Create Artifact Container failed: The artifact name apache_incubator-kie-kogito-apps is not valid. Request URL https://pipelinesghubeus21.actions.githubusercontent.com/IrxxfEV2hwRdFBDc1qz8RvI5rKuecFt7wcQhsWaTzPACOSrcv9/_apis/pipelines/workflows/13112059013/artifacts?api-version=6.0-preview
```

The origin of the issue is not clear, though the archive-artifacts configurations are outdated anyway - cypress is not anymore in kogito-apps.