### PR TITLE
[NO ISSUE] combine .rat-excludes files for source zip root

### DIFF
--- a/tools/DevelopmentNotes.md
+++ b/tools/DevelopmentNotes.md
@@ -1,0 +1,41 @@
+<!--
+  Licensed to the Apache Software Foundation (ASF) under one
+  or more contributor license agreements.  See the NOTICE file
+  distributed with this work for additional information
+  regarding copyright ownership.  The ASF licenses this file
+  to you under the Apache License, Version 2.0 (the
+  "License"); you may not use this file except in compliance
+  with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing,
+  software distributed under the License is distributed on an
+  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+  KIND, either express or implied.  See the License for the
+  specific language governing permissions and limitations
+  under the License.
+  -->
+
+## zip-sources-all.sh
+
+Clones specified repositories, adds some files for root directory, and zips them as a source code distribution.
+
+To test `zip-sources-all.sh` locally,
+
+- Edit `./tools/zip-sources-all.sh` to uncomment and set variables
+
+for example:
+```
+TARGET_VERSION="10.1.0"
+SOURCES_DEFAULT_BRANCH="main"
+GIT_AUTHOR="apache"
+
+SOURCES_REPOSITORIES="incubator-kie-drools
+incubator-kie-kogito-runtimes
+incubator-kie-kogito-apps
+incubator-kie-optaplanner
+incubator-kie-tools"
+```
+
+- Execute `./tools/zip-sources-all.sh source.zip`

--- a/tools/zip-sources-all.sh
+++ b/tools/zip-sources-all.sh
@@ -94,7 +94,7 @@ function zip_sources() {
     cat ${line}/.rat-excludes >> ${RAT_EXCLUDES_COMBINED_FILE}
     echo "" >> ${RAT_EXCLUDES_COMBINED_FILE}
   done <<< $SOURCES_REPOSITORIES
-  echo ${RAT_EXCLUDES_COMBINED_FILE} >> ${RAT_EXCLUDES_COMBINED_FILE}
+  echo ${RAT_EXCLUDES_COMBINED_FILE} >> ${RAT_EXCLUDES_COMBINED_FILE} #Add the filename itself to the file
   popd
 
   #Add LICENSE, NOTICE and DISCLAIMER files to the root folder of the zip file

--- a/tools/zip-sources-all.sh
+++ b/tools/zip-sources-all.sh
@@ -86,6 +86,17 @@ function zip_sources() {
 
   done <<< $SOURCES_REPOSITORIES
 
+  #Combining .rat-excludes files
+  pushd ${SOURCES_DIRECTORY_NAME}
+  echo "Combining .rat-excludes files"
+  RAT_EXCLUDES_COMBINED_FILE=".rat-excludes-combined"
+  while read line; do
+    cat ${line}/.rat-excludes >> ${RAT_EXCLUDES_COMBINED_FILE}
+    echo "" >> ${RAT_EXCLUDES_COMBINED_FILE}
+  done <<< $SOURCES_REPOSITORIES
+  echo ${RAT_EXCLUDES_COMBINED_FILE} >> ${RAT_EXCLUDES_COMBINED_FILE}
+  popd
+
   #Add LICENSE, NOTICE and DISCLAIMER files to the root folder of the zip file
   echo "Adding LICENSE, NOTICE and DISCLAIMER files to the zip file"
   cp ./tools/zip-sources-files/{LICENSE,NOTICE,DISCLAIMER} ${SOURCES_DIRECTORY_NAME}


### PR DESCRIPTION
Creates `.rat-excludes-combined` file under the source zip root directory by combining `.rat-excludes` files under each repository, so that verify steps can be easier.

After merged, I'll file a PR to update the verify steps in https://kie.apache.org/docs/community/verify