### PR TITLE
Revert "Downgrade build-chain to 3.5.5 to fix problems running PR checks"

### DIFF
--- a/.ci/actions/build-chain/action.yml
+++ b/.ci/actions/build-chain/action.yml
@@ -33,7 +33,7 @@ runs:
   steps:
     - name: Build Chain Tool Execution
       id: build-chain
-      uses: kiegroup/github-action-build-chain@v3.5.5
+      uses: kiegroup/github-action-build-chain@v3
       with:
         definition-file: ${{ inputs.definition-file }}
         flow-type: ${{ inputs.flow-type }}


### PR DESCRIPTION


This reverts commit 1765eb0afa351ab1308499e5433e5c956a775e73.