### PR TITLE
Increase the heap size in the setup-branch job

### DIFF
--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -21,6 +21,7 @@ pipeline {
 
     environment {
         KOGITO_CI_EMAIL_TO = credentials("${JENKINS_EMAIL_CREDS_ID}")
+        MAVEN_OPTS = "-Xms1024m -Xmx12g"
     }
 
     stages {


### PR DESCRIPTION
Setup-branch had multiple failures when running pnpm bootstrap due to there not being enough space in the heap. It passed when I passed the following MAVEN_OPTS as a parameter in the pipeline. Adding it here to reduce parameter bloat