### PR TITLE
Apache 10.2.0 release: Cleaning up code used for testing pipelines

### DIFF
--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -48,7 +48,9 @@ if (isMainStream()) {
 createSetupBranchJob()
 
 // Nightly
+if (GIT_BRANCH != '2.2.x') {
 setupNightlyJob()
+}
 
 // Weekly
 setupWeeklyJob()

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -53,7 +53,9 @@ setupNightlyJob()
 }
 
 // Weekly
+if (Utils.getStream(this) != '2.2.x') {
 setupWeeklyJob()
+}
 
 // Release
 setupReleaseArtifactsJob()

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -48,7 +48,7 @@ if (isMainStream()) {
 createSetupBranchJob()
 
 // Nightly
-if (GIT_BRANCH != '2.2.x') {
+if (Utils.getStream(this) != '2.2.x') {
 setupNightlyJob()
 }
 


### PR DESCRIPTION
In preparation for the 10.2.0 release, I created a a 2.2.x test version to ensure the pipelines are release-ready. The 2.2.x version is not needed to be built nightly nor weekly, so removing it from the nightly/weekly jobs.