### PR TITLE
Apache 10.2.0 release: Disable nightly and weekly jobs for 2.2.x drools-seed

### DIFF
--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -1,5 +1,10 @@
 generation_config:
   missing_environment: ignore
+job_types:
+  nightly:
+    disabled: true
+  other:
+    disabled: true
 environments:
   native:
     env_vars:


### PR DESCRIPTION
In preparation for the 10.2.0 release, I created a a 2.2.x test version to ensure the pipelines are release-ready. The 2.2.x version is not needed to be built nightly nor weekly, so removing it from the nightly/weekly jobs.

I'm using the "other" job type as that's what's referenced in the [JobType.groovy](https://github.com/apache/incubator-kie-kogito-pipelines/blob/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl/model/JobType.groovy) and after doing a search for JobType.OTHER it's currently only used for the weekly job.