### PR TITLE
[incubator-kie-issues#2259] Dumping dependency trees to different file

### DIFF
--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -20,18 +20,18 @@ default:
         export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_UPSTREAM }}
         bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS_UPSTREAM }}; fi"
     current: |
-      mvn dependency:tree clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
+      mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
     upstream: |
-      mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
+      mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
 
 build:
   - project: apache/incubator-kie-drools
     build-command:
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.DROOLS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
 
   - project: apache/incubator-kie-optaplanner
     build-command:
@@ -44,9 +44,9 @@ build:
     build-command:
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_RUNTIMES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         current: |
           export MVN_EXCLUSION="!org.kie.kogito:kogito-serverless-workflow-executor-python,!org.drools:drools-quarkus-rules-integration-test,!org.kie.kogito:jbpm-tests,!org.jbpm:jbpm-quarkus-integration-test,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:kogito-spring-boot-integration-tests,!org.kie.kogito:integration-tests-springboot-processes-persistence-common,!org.kie.kogito:integration-tests-springboot-decisions-it,!org.kie.kogito:integration-tests-springboot-kafka-it,!org.kie.kogito:integration-tests-springboot-norest-it,!org.kie.kogito:integration-tests-springboot-processes-it,!org.kie.kogito:integration-tests-springboot-processes-persistence-it,!org.kie.kogito:integration-tests-springboot-processes-infinispan,!org.kie.kogito:integration-tests-springboot-processes-jdbc,!org.kie.kogito:integration-tests-springboot-processes-mongodb,!org.kie.kogito:integration-tests-springboot-processes-postgresql"
@@ -57,9 +57,9 @@ build:
     build-command: 
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_APPS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         # Make sure you add -pl into MVN_PROJECTS_EXCLUSION when adding some exclusions
         current: |
@@ -72,14 +72,14 @@ build:
       # First install the main pom
       # Then build the required submodule pom if provided, otherwise build whole
       current: |
-        mvn dependency:tree -pl :kogito-examples clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
-        mvn dependency:tree -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}pom.xml clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true -pl :kogito-examples clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}pom.xml clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         # In case of deploy, deploy the parent poms only.
         current: |
-          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.BUILD_MVN_OPTS }} ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
+          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.BUILD_MVN_OPTS }} ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
   # - project: kiegroup/kie-jpmml-integration
   #   build-command:
   #     current: |

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -9,6 +9,7 @@ pre: |
   echo "BUILD_MVN_OPTS_CURRENT=${{ env.BUILD_MVN_OPTS_CURRENT }}"
   echo "QUARKUS_VERSION=${{ env.QUARKUS_VERSION }}"
   echo "ENABLE_DEPLOY=${{ env.ENABLE_DEPLOY }}"
+  echo "GITHUB_WORKSPACE=${{ env.GITHUB_WORKSPACE }}"
 
 default:
   build-command:
@@ -20,18 +21,18 @@ default:
         export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_UPSTREAM }}
         bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS_UPSTREAM }}; fi"
     current: |
-      mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
+      mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
     upstream: |
-      mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
+      mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
 
 build:
   - project: apache/incubator-kie-drools
     build-command:
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.DROOLS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
 
   - project: apache/incubator-kie-optaplanner
     build-command:
@@ -44,9 +45,9 @@ build:
     build-command:
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_RUNTIMES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         current: |
           export MVN_EXCLUSION="!org.kie.kogito:kogito-serverless-workflow-executor-python,!org.drools:drools-quarkus-rules-integration-test,!org.kie.kogito:jbpm-tests,!org.jbpm:jbpm-quarkus-integration-test,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:kogito-spring-boot-integration-tests,!org.kie.kogito:integration-tests-springboot-processes-persistence-common,!org.kie.kogito:integration-tests-springboot-decisions-it,!org.kie.kogito:integration-tests-springboot-kafka-it,!org.kie.kogito:integration-tests-springboot-norest-it,!org.kie.kogito:integration-tests-springboot-processes-it,!org.kie.kogito:integration-tests-springboot-processes-persistence-it,!org.kie.kogito:integration-tests-springboot-processes-infinispan,!org.kie.kogito:integration-tests-springboot-processes-jdbc,!org.kie.kogito:integration-tests-springboot-processes-mongodb,!org.kie.kogito:integration-tests-springboot-processes-postgresql"
@@ -57,9 +58,9 @@ build:
     build-command: 
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_APPS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         # Make sure you add -pl into MVN_PROJECTS_EXCLUSION when adding some exclusions
         current: |
@@ -72,14 +73,14 @@ build:
       # First install the main pom
       # Then build the required submodule pom if provided, otherwise build whole
       current: |
-        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true -pl :kogito-examples clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
-        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}pom.xml clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true -pl :kogito-examples clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}pom.xml clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         # In case of deploy, deploy the parent poms only.
         current: |
-          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.BUILD_MVN_OPTS }} ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
+          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.BUILD_MVN_OPTS }} ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
   # - project: kiegroup/kie-jpmml-integration
   #   build-command:
   #     current: |

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -9,6 +9,7 @@ pre: |
   echo "BUILD_MVN_OPTS_CURRENT=${{ env.BUILD_MVN_OPTS_CURRENT }}"
   echo "QUARKUS_VERSION=${{ env.QUARKUS_VERSION }}"
   echo "ENABLE_DEPLOY=${{ env.ENABLE_DEPLOY }}"
+  echo "GITHUB_WORKSPACE=${{ env.GITHUB_WORKSPACE }}"
   echo "DEPENDENCY_TREE_FILE=${{ env.DEPENDENCY_TREE_FILE }}"
 
 default:
@@ -21,18 +22,18 @@ default:
         export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_UPSTREAM }}
         bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS_UPSTREAM }}; fi"
     current: |
-      mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
+      mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
     upstream: |
-      mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
+      mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
 
 build:
   - project: apache/incubator-kie-drools
     build-command:
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.DROOLS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
 
   - project: apache/incubator-kie-optaplanner
     build-command:
@@ -45,9 +46,9 @@ build:
     build-command:
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_RUNTIMES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         current: |
           export MVN_EXCLUSION="!org.kie.kogito:kogito-serverless-workflow-executor-python,!org.drools:drools-quarkus-rules-integration-test,!org.kie.kogito:jbpm-tests,!org.jbpm:jbpm-quarkus-integration-test,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:kogito-spring-boot-integration-tests,!org.kie.kogito:integration-tests-springboot-processes-persistence-common,!org.kie.kogito:integration-tests-springboot-decisions-it,!org.kie.kogito:integration-tests-springboot-kafka-it,!org.kie.kogito:integration-tests-springboot-norest-it,!org.kie.kogito:integration-tests-springboot-processes-it,!org.kie.kogito:integration-tests-springboot-processes-persistence-it,!org.kie.kogito:integration-tests-springboot-processes-infinispan,!org.kie.kogito:integration-tests-springboot-processes-jdbc,!org.kie.kogito:integration-tests-springboot-processes-mongodb,!org.kie.kogito:integration-tests-springboot-processes-postgresql"
@@ -58,9 +59,9 @@ build:
     build-command: 
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_APPS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         # Make sure you add -pl into MVN_PROJECTS_EXCLUSION when adding some exclusions
         current: |
@@ -73,14 +74,14 @@ build:
       # First install the main pom
       # Then build the required submodule pom if provided, otherwise build whole
       current: |
-        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true -pl :kogito-examples clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
-        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}pom.xml clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true -pl :kogito-examples clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}pom.xml clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         # In case of deploy, deploy the parent poms only.
         current: |
-          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.BUILD_MVN_OPTS }} ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
+          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.BUILD_MVN_OPTS }} ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
   # - project: kiegroup/kie-jpmml-integration
   #   build-command:
   #     current: |

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -9,7 +9,7 @@ pre: |
   echo "BUILD_MVN_OPTS_CURRENT=${{ env.BUILD_MVN_OPTS_CURRENT }}"
   echo "QUARKUS_VERSION=${{ env.QUARKUS_VERSION }}"
   echo "ENABLE_DEPLOY=${{ env.ENABLE_DEPLOY }}"
-  echo "GITHUB_WORKSPACE=${{ env.GITHUB_WORKSPACE }}"
+  echo "DEPENDENCY_TREE_FILE=${{ env.DEPENDENCY_TREE_FILE }}"
 
 default:
   build-command:
@@ -21,18 +21,18 @@ default:
         export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_UPSTREAM }}
         bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS_UPSTREAM }}; fi"
     current: |
-      mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
+      mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
     upstream: |
-      mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
+      mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
 
 build:
   - project: apache/incubator-kie-drools
     build-command:
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.DROOLS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
 
   - project: apache/incubator-kie-optaplanner
     build-command:
@@ -45,9 +45,9 @@ build:
     build-command:
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_RUNTIMES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         current: |
           export MVN_EXCLUSION="!org.kie.kogito:kogito-serverless-workflow-executor-python,!org.drools:drools-quarkus-rules-integration-test,!org.kie.kogito:jbpm-tests,!org.jbpm:jbpm-quarkus-integration-test,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:kogito-spring-boot-integration-tests,!org.kie.kogito:integration-tests-springboot-processes-persistence-common,!org.kie.kogito:integration-tests-springboot-decisions-it,!org.kie.kogito:integration-tests-springboot-kafka-it,!org.kie.kogito:integration-tests-springboot-norest-it,!org.kie.kogito:integration-tests-springboot-processes-it,!org.kie.kogito:integration-tests-springboot-processes-persistence-it,!org.kie.kogito:integration-tests-springboot-processes-infinispan,!org.kie.kogito:integration-tests-springboot-processes-jdbc,!org.kie.kogito:integration-tests-springboot-processes-mongodb,!org.kie.kogito:integration-tests-springboot-processes-postgresql"
@@ -58,9 +58,9 @@ build:
     build-command: 
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_APPS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         # Make sure you add -pl into MVN_PROJECTS_EXCLUSION when adding some exclusions
         current: |
@@ -73,14 +73,14 @@ build:
       # First install the main pom
       # Then build the required submodule pom if provided, otherwise build whole
       current: |
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true -pl :kogito-examples clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}pom.xml clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true -pl :kogito-examples clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}pom.xml clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         # In case of deploy, deploy the parent poms only.
         current: |
-          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/mvn_dependency_tree.txt -DappendOutput=true -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.BUILD_MVN_OPTS }} ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
+          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DoutputFile=${{ env.DEPENDENCY_TREE_FILE }}/mvn_dependency_tree.txt -DappendOutput=true -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.BUILD_MVN_OPTS }} ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
   # - project: kiegroup/kie-jpmml-integration
   #   build-command:
   #     current: |

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -20,18 +20,18 @@ default:
         export INTEGRATION_BRANCH=${{ env.INTEGRATION_BRANCH_UPSTREAM }}
         bash -c "if [ ! -z '${{ env.BUILD_ENVIRONMENT }}' ] && [ -f .ci/environments/update.sh ]; then .ci/environments/update.sh ${{ env.BUILD_ENVIRONMENT }} ${{ env.BUILD_ENVIRONMENT_OPTIONS_UPSTREAM }}; fi"
     current: |
-      mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
+      mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }}
     upstream: |
-      mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
+      mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }}
 
 build:
   - project: apache/incubator-kie-drools
     build-command:
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.DROOLS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
 
   - project: apache/incubator-kie-optaplanner
     build-command:
@@ -44,9 +44,9 @@ build:
     build-command:
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_RUNTIMES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         current: |
           export MVN_EXCLUSION="!org.kie.kogito:kogito-serverless-workflow-executor-python,!org.drools:drools-quarkus-rules-integration-test,!org.kie.kogito:jbpm-tests,!org.jbpm:jbpm-quarkus-integration-test,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:kogito-spring-boot-integration-tests,!org.kie.kogito:integration-tests-springboot-processes-persistence-common,!org.kie.kogito:integration-tests-springboot-decisions-it,!org.kie.kogito:integration-tests-springboot-kafka-it,!org.kie.kogito:integration-tests-springboot-norest-it,!org.kie.kogito:integration-tests-springboot-processes-it,!org.kie.kogito:integration-tests-springboot-processes-persistence-it,!org.kie.kogito:integration-tests-springboot-processes-infinispan,!org.kie.kogito:integration-tests-springboot-processes-jdbc,!org.kie.kogito:integration-tests-springboot-processes-mongodb,!org.kie.kogito:integration-tests-springboot-processes-postgresql"
@@ -57,9 +57,9 @@ build:
     build-command: 
       current: |
         export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_APPS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         # Make sure you add -pl into MVN_PROJECTS_EXCLUSION when adding some exclusions
         current: |
@@ -72,14 +72,14 @@ build:
       # First install the main pom
       # Then build the required submodule pom if provided, otherwise build whole
       current: |
-        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true -pl :kogito-examples clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
-        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}pom.xml clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true -pl :kogito-examples clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
+        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true -f ${{ env.KOGITO_EXAMPLES_SUBFOLDER_POM }}pom.xml clean install ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS }}
       upstream: |
-        mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
+        mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true clean install -DskipTests -DskipITs ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_EXAMPLES_BUILD_MVN_OPTS_UPSTREAM }}
       after:
         # In case of deploy, deploy the parent poms only.
         current: |
-          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DoutputFile=`pwd`/mvn_dependency_tree.txt -DappendOutput=true -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.BUILD_MVN_OPTS }} ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
+          bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then mvn dependency:tree -DoutputFile=${{ github.workspace }}/mvn_dependency_tree.txt -DappendOutput=true -DskipTests -DskipITs -pl .,kogito-quarkus-examples,kogito-springboot-examples,serverless-workflow-examples deploy ${{ env.BUILD_MVN_OPTS }} ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_EXAMPLES_DEPLOY_MVN_OPTS }}; else echo 'No deploy is scheduled'; fi"
   # - project: kiegroup/kie-jpmml-integration
   #   build-command:
   #     current: |


### PR DESCRIPTION
Fix https://github.com/apache/incubator-kie-issues/issues/2259


With this PR:
1. dependency tree are not dumped on the build log anymore but on a specific file
2. a new job "Upload Dependency Trees" is execute after the build
3. the dependency tree log could be downloaded from the link that will be shown inside the "Upload Dependency Trees" job

Other PRs in the ensamble

https://github.com/apache/incubator-kie-drools/pull/6593
https://github.com/apache/incubator-kie-kogito-runtimes/pull/4204
https://github.com/apache/incubator-kie-kogito-apps/pull/2304
https://github.com/apache/incubator-kie-kogito-examples/pull/2179