### PR TITLE
NO-ISSUE: workaround buildchain jenkinsfile reference to GITHUB_WORKSPACE

### DIFF
--- a/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
+++ b/dsl/seed/jenkinsfiles/Jenkinsfile.buildchain
@@ -57,6 +57,10 @@ pipeline {
         timestamps()
         timeout(time: timeoutValue, unit: 'MINUTES')
     }
+    environment {
+        GITHUB_WORKSPACE = "${WORKSPACE}" // faking GITHUB_WORKSPACE env var for the build-chain config mvn dependency:tree output
+        DEPENDENCY_TREE_FILE = "mvn_dependency_tree.txt"
+    }
     stages {
         stage('Initialize') {
             steps {


### PR DESCRIPTION
In attempt to reduce size of logs, the applicable build-chain config was adjusted to write mvn dependency:tree verbose output into a file inside workspace. The primary focus was GitHub PR checks, so the destination is now defined as env.GITHUB_WORKSPACE.

While this fits GitHub actions, obviously there's problem in jenkins, where the same build-chain configuration file is shared by the nightly jobs.
There were two options:
1. refactor the build-chain configuration to use a different env variable, which then would need to be explicitly set in all the workflows (quite many all around the repos).
2. adjust Jenkinsfile that uses the shared build-chain configuration to "fake" env.GITHUB_WORKSPACE while providing explanation in a comment. Which isolates the change to a single Jenkinsfile.

The PR here implements option 2 from the above.