### PR TITLE
kie-issues##2371: 10.3.x+ stream: Move kogito-runtimes to drools preserving Git-history and top-level directory structure

### DIFF
--- a/.ci/buildchain-config-pr-cdb.yaml
+++ b/.ci/buildchain-config-pr-cdb.yaml
@@ -35,16 +35,6 @@ build:
       downstream: |
         mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_DOWNSTREAM }}
   
-  - project: apache/incubator-kie-kogito-runtimes
-    build-command:
-      current: |
-        export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_RUNTIMES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
-      upstream: |
-        mvn dependency:tree clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
-      downstream: |
-        mvn dependency:tree clean install -Dquickly -Dfull ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_DOWNSTREAM }}
-
   - project: apache/incubator-kie-kogito-apps
     build-command: 
       current: |

--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -3,7 +3,6 @@ import org.jenkinsci.plugins.workflow.libs.Library
 @Library('jenkins-pipeline-shared-libraries')_
 
 // Deploy jobs
-RUNTIMES_DEPLOY = 'kogito-runtimes.build-and-deploy'
 APPS_DEPLOY = 'kogito-apps.build-and-deploy'
 EXAMPLES_DEPLOY = 'kogito-examples.build-and-deploy'
 QUARKUS_PLATFORM_DEPLOY = 'quarkus-platform.deploy'
@@ -54,24 +53,6 @@ pipeline {
 
         stage('Build & Deploy artifacts') {
             parallel {
-                stage('Build & Deploy Kogito Runtimes') {
-                    steps {
-                        script {
-                            def buildParams = getDefaultBuildParams()
-                            addSkipTestsParam(buildParams)
-                            addSkipIntegrationTestsParam(buildParams)
-
-                            // images and operator deploy testing will use older working artifacts if that one fails
-                            buildJob(RUNTIMES_DEPLOY, buildParams)
-                        }
-                    }
-                    post {
-                        failure {
-                            addFailedStage(RUNTIMES_DEPLOY)
-                        }
-                    }
-                }
-
                 stage('Build & Deploy Kogito Apps') {
                     steps {
                         script {

--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -2,7 +2,6 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 @Library('jenkins-pipeline-shared-libraries')_
 
-kogitoRuntimesRepo = 'kogito-runtimes'
 kogitoAppsRepo = 'kogito-apps'
 
 ARTIFACTS_STAGING_STAGE = 'stage.artifacts.staging'
@@ -51,17 +50,6 @@ pipeline {
                 always {
                     setReleasePropertyIfneeded('release.version', getReleaseVersion())
                     setReleasePropertyIfneeded('git.tag.name', getGitTagName())
-                }
-            }
-        }
-
-        stage('Build & Deploy Kogito Runtimes') {
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams(getReleaseVersion())
-                    addSkipTestsParam(buildParams)
-                    addStringParam(buildParams, 'DROOLS_VERSION', getReleaseVersion())
-                    buildJob(getDeployJobName(kogitoRuntimesRepo), buildParams)
                 }
             }
         }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -32,22 +32,6 @@ pipeline {
             }
         }
 
-        stage('Init Kogito Runtimes') {
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams()
-                    addDroolsVersionParam(buildParams)
-                    addKogitoVersionParam(buildParams)
-                    buildJob('kogito-runtimes', buildParams)
-                }
-            }
-            post {
-                failure {
-                    addFailedStage('kogito-runtimes')
-                }
-            }
-        }
-
         stage('Init Kogito Apps') {
             steps {
                 script {

--- a/.ci/jenkins/Jenkinsfile.weekly
+++ b/.ci/jenkins/Jenkinsfile.weekly
@@ -3,7 +3,6 @@ import org.jenkinsci.plugins.workflow.libs.Library
 @Library('jenkins-pipeline-shared-libraries')_
 
 // Deploy jobs
-RUNTIMES_DEPLOY = 'kogito-runtimes.weekly-deploy'
 APPS_DEPLOY = 'kogito-apps.weekly-deploy'
 
 // Map of executed jobs
@@ -44,22 +43,6 @@ pipeline {
                     echo "weekly tag is ${env.WEEKLY_TAG}"
 
                     currentBuild.displayName = env.WEEKLY_TAG
-                }
-            }
-        }
-
-        stage('Build & Deploy Kogito Runtimes') {
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams()
-                    addSkipTestsParam(buildParams)
-                    addSkipIntegrationTestsParam(buildParams)
-                    buildJob(RUNTIMES_DEPLOY, buildParams)
-                }
-            }
-            post {
-                failure {
-                    addFailedStage(RUNTIMES_DEPLOY)
                 }
             }
         }

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -24,8 +24,6 @@ disable:
 repositories:
 - name: incubator-kie-kogito-pipelines
   job_display_name: kogito-pipelines
-- name: incubator-kie-kogito-runtimes
-  job_display_name: kogito-runtimes
 - name: incubator-kie-kogito-apps
   job_display_name: kogito-apps
 - name: incubator-kie-kogito-examples

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -201,7 +201,6 @@ void setupZipSourcesJob() {
         parameters {
             textParam('SOURCES_REPOSITORIES',
                     '''incubator-kie-drools
-incubator-kie-kogito-runtimes
 incubator-kie-kogito-apps
 incubator-kie-kogito-images
 incubator-kie-tools

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -39,7 +39,7 @@ if (isMainStream()) {
     KogitoJobUtils.createQuarkusPlatformUpdateToolsJob(this, 'kogito')
 
     KogitoJobUtils.createMainQuarkusUpdateToolsJob(this,
-        [ 'kogito-runtimes', 'kogito-examples', 'kogito-docs', 'kogito-images' ],
+        [ 'kogito-examples', 'kogito-docs', 'kogito-images' ],
         [ 'radtriste', 'cristianonicolai' ]
     )
 }

--- a/.ci/jenkins/tests/src/test/groovy/org/kie/jenkins/JenkinsfileNightly.groovy
+++ b/.ci/jenkins/tests/src/test/groovy/org/kie/jenkins/JenkinsfileNightly.groovy
@@ -72,7 +72,6 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
         runJenkinsfileAndAssertSuccess()
 
         assertDeployBuildCalls([
-            'kogito-runtimes' : [:],
             'kogito-apps' : [:],
             'kogito-examples': [:],
         ])
@@ -92,7 +91,6 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
         runJenkinsfileAndAssertSuccess()
 
         assertDeployBuildCalls([
-            'kogito-runtimes' : [:],
             'kogito-apps' : [:],
             'kogito-examples': [:],
         ], true)
@@ -105,12 +103,6 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
     @Test
     void deploy_failing() throws Exception {
         helper.registerAllowedMethod('build', [Map.class], { map ->
-            if (map.get('job') == 'kogito-runtimes.build-and-deploy') {
-                return [
-                    result: 'FAILURE',
-                    absoluteUrl: 'URL',
-                ]
-            }
             return [
                 result: 'SUCCESS',
                 absoluteUrl: 'URL',
@@ -120,7 +112,6 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
         runJenkinsfileAndAssertUnstable()
 
         assertDeployBuildCalls([
-            'kogito-runtimes' : [:],
             'kogito-apps' : [:],
             'kogito-examples': [:],
         ])
@@ -148,7 +139,6 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
         runJenkinsfileAndAssertUnstable()
 
         assertDeployBuildCalls([
-            'kogito-runtimes' : [:],
             'kogito-apps' : [:],
             'kogito-examples': [:],
         ])

--- a/.ci/jenkins/tests/src/test/groovy/org/kie/jenkins/JenkinsfileNightly.groovy
+++ b/.ci/jenkins/tests/src/test/groovy/org/kie/jenkins/JenkinsfileNightly.groovy
@@ -103,6 +103,12 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
     @Test
     void deploy_failing() throws Exception {
         helper.registerAllowedMethod('build', [Map.class], { map ->
+            if (map.get('job') == 'kogito-apps.build-and-deploy') {
+                return [
+                    result: 'FAILURE',
+                    absoluteUrl: 'URL',
+                ]
+            }
             return [
                 result: 'SUCCESS',
                 absoluteUrl: 'URL',

--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -1,18 +1,14 @@
 version: "2.1"
 dependencies:
   - project: apache/incubator-kie-drools
-
-  - project: apache/incubator-kie-kogito-runtimes
-    dependencies:
-      - project: apache/incubator-kie-drools
   
   - project: apache/incubator-kie-kogito-apps
     dependencies:
-      - project: apache/incubator-kie-kogito-runtimes
+      - project: apache/incubator-kie-drools
 
   - project: apache/incubator-kie-kogito-examples
     dependencies:
-      - project: apache/incubator-kie-kogito-runtimes
+      - project: apache/incubator-kie-drools
       - project: apache/incubator-kie-kogito-apps
   
   # - project: kiegroup/kie-jpmml-integration

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -34,21 +34,6 @@ build:
         mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
       upstream: |
         mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
-
-  - project: apache/incubator-kie-kogito-runtimes
-    build-command:
-      current: |
-        export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_RUNTIMES_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean -Dfull ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
-      upstream: |
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS_UPSTREAM }}
-      after:
-        current: |
-          export MVN_EXCLUSION="!org.drools:drools-quarkus-rules-integration-test,!org.kie.kogito:jbpm-tests,!org.jbpm:jbpm-quarkus-integration-test,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:integration-tests-quarkus-norest,!org.kie.kogito:kogito-spring-boot-integration-tests,!org.kie.kogito:integration-tests-springboot-processes-persistence-common,!org.kie.kogito:integration-tests-springboot-decisions-it,!org.kie.kogito:integration-tests-springboot-kafka-it,!org.kie.kogito:integration-tests-springboot-norest-it,!org.kie.kogito:integration-tests-springboot-processes-it,!org.kie.kogito:integration-tests-springboot-processes-persistence-it,!org.kie.kogito:integration-tests-springboot-processes-infinispan,!org.kie.kogito:integration-tests-springboot-processes-jdbc,!org.kie.kogito:integration-tests-springboot-processes-mongodb,!org.kie.kogito:integration-tests-springboot-processes-postgresql"
-          echo  ${{ env.MVN_EXCLUSION }}
-          mvn clean package -DskipTests -Dfull artifact:3.5.1:compare -Dcompare.fail=false -Dcompare.aggregate.only=true -Dreference.repo=file:~/.m2/repository -pl ${{ env.MVN_EXCLUSION }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_RUNTIMES_BUILD_MVN_OPTS }}
-        upstream: |
-          echo "Skipping dependency tree comparison for upstream builds"
   - project: apache/incubator-kie-kogito-apps
     build-command: 
       current: |

--- a/README.md
+++ b/README.md
@@ -28,7 +28,6 @@ This repository contains some of the pipelines of Kogito project.
 
 Apart from this repository, pipelines are also concerning those repositories:
 
-* [kogito-runtimes](https://github.com/apache/incubator-kie-kogito-runtimes)
 * [kogito-apps](https://github.com/apache/incubator-kie-kogito-apps)
 * [kogito-examples](https://github.com/apache/incubator-kie-kogito-examples)
 * [kogito-images](https://github.com/apache/incubator-kie-kogito-images)

--- a/docs/current_pipelines.md
+++ b/docs/current_pipelines.md
@@ -11,7 +11,6 @@ Here is a small overview of current pipelines existing around Kogito project.
   - https://github.com/kiegroup/kie-pmml-integration
 - Kogito
   - https://github.com/apache/incubator-kie-kogito-pipelines
-  - https://github.com/apache/incubator-kie-kogito-runtimes
   - https://github.com/apache/incubator-kie-kogito-apps
   - https://github.com/apache/incubator-kie-kogito-examples
   - https://github.com/apache/incubator-kie-kogito-images

--- a/tools/zip-sources-all.sh
+++ b/tools/zip-sources-all.sh
@@ -27,7 +27,6 @@
 ## Configuration in format "repository_name;branch(if-override-needed)"
 ## - eg.not all repositories have main branch
 #SOURCES_REPOSITORIES="incubator-kie-drools
-#incubator-kie-kogito-runtimes
 #incubator-kie-kogito-apps
 #incubator-kie-kogito-images
 #incubator-kie-tools

--- a/tools/zip-sources-files/BUILD
+++ b/tools/zip-sources-files/BUILD
@@ -46,17 +46,12 @@ git init .
 mvn clean install -DskipTests -Dfull -Donly.reproducible=true
 cd ..
 
-2. Build Kogito Runtimes:
-cd incubator-kie-kogito-runtimes
-mvn clean install -DskipTests -Dfull -Donly.reproducible=true
-cd ..
-
-3. Build Kogito Apps:
+2. Build Kogito Apps:
 cd incubator-kie-kogito-apps
 mvn clean install -DskipTests -Dfull -Donly.reproducible=true -Pjitexecutor-native
 cd ..
 
-4. Build Kogito Images:
+3. Build Kogito Images:
 cd incubator-kie-kogito-images
 cekit --descriptor kogito-base-builder-image.yaml build docker --platform linux/amd64
 make build-image KOGITO_APPS_TARGET_BRANCH=main ignore_test=true image_name=kogito-data-index-ephemeral
@@ -67,7 +62,7 @@ make build-image KOGITO_APPS_TARGET_BRANCH=main ignore_test=true image_name=kogi
 make build-image KOGITO_APPS_TARGET_BRANCH=main ignore_test=true image_name=kogito-jobs-service-postgresql
 cd ..
 
-5. Build KIE Tools:
+4. Build KIE Tools:
 cd incubator-kie-tools
 git init .
 git config user.name "Builder"

--- a/tools/zip-sources-files/build.sh
+++ b/tools/zip-sources-files/build.sh
@@ -47,11 +47,6 @@ build_components() {
     mvn clean install -DskipTests -Dfull -Donly.reproducible=true
     cd ..
 
-    # Build Kogito Runtimes
-    cd incubator-kie-kogito-runtimes || exit 1
-    mvn clean install -DskipTests -Dfull -Donly.reproducible=true
-    cd ..
-
     # Build Kogito Apps
     cd incubator-kie-kogito-apps || exit 1
     mvn clean install -DskipTests -Dfull -Donly.reproducible=true -Pjitexecutor-native


### PR DESCRIPTION
Update files to reflect kogito-runtimes being merged into drools

Related PRs:
- https://github.com/apache/incubator-kie-drools/pull/6804 Merges kogito-runtimes into the drools repository
- https://github.com/apache/incubator-kie-kogito-runtimes/pull/4347 Update kogito-runtimes readme to show new archived state
- https://github.com/apache/incubator-kie-tools/pull/3670 Update kie-tools drools-and-kogito package to reflext changes

