### PR TITLE
kie-issues#2378: 10.3.x+ stream: Move kogito-apps to drools preserving Git-history and top-level directory structure

### DIFF
--- a/.ci/buildchain-config-pr-cdb.yaml
+++ b/.ci/buildchain-config-pr-cdb.yaml
@@ -35,16 +35,6 @@ build:
       downstream: |
         mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_DOWNSTREAM }}
   
-  - project: apache/incubator-kie-kogito-apps
-    build-command: 
-      current: |
-        export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_APPS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
-      upstream: |
-        mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
-      downstream: |
-        mvn dependency:tree clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_DOWNSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_DOWNSTREAM }}
-
   - project: apache/incubator-kie-kogito-examples
     build-command:
       # First install the main pom

--- a/.ci/jenkins/Jenkinsfile.nightly
+++ b/.ci/jenkins/Jenkinsfile.nightly
@@ -3,7 +3,6 @@ import org.jenkinsci.plugins.workflow.libs.Library
 @Library('jenkins-pipeline-shared-libraries')_
 
 // Deploy jobs
-APPS_DEPLOY = 'kogito-apps.build-and-deploy'
 EXAMPLES_DEPLOY = 'kogito-examples.build-and-deploy'
 QUARKUS_PLATFORM_DEPLOY = 'quarkus-platform.deploy'
 
@@ -53,24 +52,6 @@ pipeline {
 
         stage('Build & Deploy artifacts') {
             parallel {
-                stage('Build & Deploy Kogito Apps') {
-                    steps {
-                        script {
-                            def buildParams = getDefaultBuildParams()
-                            addSkipTestsParam(buildParams)
-                            addSkipIntegrationTestsParam(buildParams)
-
-                            // images and operator deploy testing will use older working artifacts if that one fails
-                            buildJob(APPS_DEPLOY, buildParams)
-                        }
-                    }
-                    post {
-                        failure {
-                            addFailedStage(APPS_DEPLOY)
-                        }
-                    }
-                }
-
                 stage('Deploy Quarkus platform') {
                     steps {
                         script {

--- a/.ci/jenkins/Jenkinsfile.release
+++ b/.ci/jenkins/Jenkinsfile.release
@@ -2,8 +2,6 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 @Library('jenkins-pipeline-shared-libraries')_
 
-kogitoAppsRepo = 'kogito-apps'
-
 ARTIFACTS_STAGING_STAGE = 'stage.artifacts.staging'
 
 JOB_PROPERTY_PREFIX = 'build'
@@ -50,16 +48,6 @@ pipeline {
                 always {
                     setReleasePropertyIfneeded('release.version', getReleaseVersion())
                     setReleasePropertyIfneeded('git.tag.name', getGitTagName())
-                }
-            }
-        }
-
-        stage('Build & Deploy Kogito Apps') {
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams(getReleaseVersion())
-                    addSkipTestsParam(buildParams)
-                    buildJob(getDeployJobName(kogitoAppsRepo), buildParams)
                 }
             }
         }

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -32,21 +32,6 @@ pipeline {
             }
         }
 
-        stage('Init Kogito Apps') {
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams()
-                    addKogitoVersionParam(buildParams)
-                    buildJob('kogito-apps', buildParams)
-                }
-            }
-            post {
-                failure {
-                    addFailedStage('kogito-apps')
-                }
-            }
-        }
-
         stage('Init Kogito Examples') {
             steps {
                 script {

--- a/.ci/jenkins/Jenkinsfile.weekly
+++ b/.ci/jenkins/Jenkinsfile.weekly
@@ -2,9 +2,6 @@ import org.jenkinsci.plugins.workflow.libs.Library
 
 @Library('jenkins-pipeline-shared-libraries')_
 
-// Deploy jobs
-APPS_DEPLOY = 'kogito-apps.weekly-deploy'
-
 // Map of executed jobs
 // See https://javadoc.jenkins.io/plugin/workflow-support/org/jenkinsci/plugins/workflow/support/steps/build/RunWrapper.html
 // for more options on built job entity
@@ -43,22 +40,6 @@ pipeline {
                     echo "weekly tag is ${env.WEEKLY_TAG}"
 
                     currentBuild.displayName = env.WEEKLY_TAG
-                }
-            }
-        }
-
-        stage('Build & Deploy Kogito Apps') {
-            steps {
-                script {
-                    def buildParams = getDefaultBuildParams()
-                    addSkipTestsParam(buildParams)
-                    addSkipIntegrationTestsParam(buildParams)
-                    buildJob(APPS_DEPLOY, buildParams)
-                }
-            }
-            post {
-                failure {
-                    addFailedStage(APPS_DEPLOY)
                 }
             }
         }

--- a/.ci/jenkins/config/branch.yaml
+++ b/.ci/jenkins/config/branch.yaml
@@ -24,8 +24,6 @@ disable:
 repositories:
 - name: incubator-kie-kogito-pipelines
   job_display_name: kogito-pipelines
-- name: incubator-kie-kogito-apps
-  job_display_name: kogito-apps
 - name: incubator-kie-kogito-examples
   job_display_name: kogito-examples
 # - name: incubator-kie-kogito-serverless-operator

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -201,7 +201,6 @@ void setupZipSourcesJob() {
         parameters {
             textParam('SOURCES_REPOSITORIES',
                     '''incubator-kie-drools
-incubator-kie-kogito-apps
 incubator-kie-kogito-images
 incubator-kie-tools
 incubator-kie-sandbox-quarkus-accelerator''',

--- a/.ci/jenkins/tests/src/test/groovy/org/kie/jenkins/JenkinsfileNightly.groovy
+++ b/.ci/jenkins/tests/src/test/groovy/org/kie/jenkins/JenkinsfileNightly.groovy
@@ -101,7 +101,7 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
     @Test
     void deploy_failing() throws Exception {
         helper.registerAllowedMethod('build', [Map.class], { map ->
-            if (map.get('job') == 'kogito-examples.build-and-deploy') {
+            if (map.get('job') == 'quarkus-platform.deploy') {
                 return [
                     result: 'FAILURE',
                     absoluteUrl: 'URL',
@@ -127,7 +127,7 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
     @Test
     void deploy_unstable() throws Exception {
         helper.registerAllowedMethod('build', [Map.class], { map ->
-            if (map.get('job') == 'kogito-examples.build-and-deploy') {
+            if (map.get('job') == 'quarkus-platform.deploy') {
                 return [
                     result: 'UNSTABLE',
                     absoluteUrl: 'URL',

--- a/.ci/jenkins/tests/src/test/groovy/org/kie/jenkins/JenkinsfileNightly.groovy
+++ b/.ci/jenkins/tests/src/test/groovy/org/kie/jenkins/JenkinsfileNightly.groovy
@@ -72,7 +72,6 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
         runJenkinsfileAndAssertSuccess()
 
         assertDeployBuildCalls([
-            'kogito-apps' : [:],
             'kogito-examples': [:],
         ])
         assertTestCallstackContains('githubscm.resolveRepository', 'incubator-kie-kogito-examples, AUTHOR, BRANCH, false, AUTHOR_CREDS_ID')
@@ -91,7 +90,6 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
         runJenkinsfileAndAssertSuccess()
 
         assertDeployBuildCalls([
-            'kogito-apps' : [:],
             'kogito-examples': [:],
         ], true)
 
@@ -103,7 +101,7 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
     @Test
     void deploy_failing() throws Exception {
         helper.registerAllowedMethod('build', [Map.class], { map ->
-            if (map.get('job') == 'kogito-apps.build-and-deploy') {
+            if (map.get('job') == 'kogito-examples.build-and-deploy') {
                 return [
                     result: 'FAILURE',
                     absoluteUrl: 'URL',
@@ -118,7 +116,6 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
         runJenkinsfileAndAssertUnstable()
 
         assertDeployBuildCalls([
-            'kogito-apps' : [:],
             'kogito-examples': [:],
         ])
 
@@ -130,7 +127,7 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
     @Test
     void deploy_unstable() throws Exception {
         helper.registerAllowedMethod('build', [Map.class], { map ->
-            if (map.get('job') == 'kogito-apps.build-and-deploy') {
+            if (map.get('job') == 'kogito-examples.build-and-deploy') {
                 return [
                     result: 'UNSTABLE',
                     absoluteUrl: 'URL',
@@ -145,7 +142,6 @@ class TestJenkinsfileNightly extends SingleFileDeclarativePipelineTest {
         runJenkinsfileAndAssertUnstable()
 
         assertDeployBuildCalls([
-            'kogito-apps' : [:],
             'kogito-examples': [:],
         ])
 

--- a/.ci/project-dependencies.yaml
+++ b/.ci/project-dependencies.yaml
@@ -1,15 +1,10 @@
 version: "2.1"
 dependencies:
   - project: apache/incubator-kie-drools
-  
-  - project: apache/incubator-kie-kogito-apps
-    dependencies:
-      - project: apache/incubator-kie-drools
 
   - project: apache/incubator-kie-kogito-examples
     dependencies:
       - project: apache/incubator-kie-drools
-      - project: apache/incubator-kie-kogito-apps
   
   # - project: kiegroup/kie-jpmml-integration
   #   dependencies:

--- a/.ci/pull-request-config.yaml
+++ b/.ci/pull-request-config.yaml
@@ -34,21 +34,6 @@ build:
         mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.DROOLS_BUILD_MVN_OPTS }}
       upstream: |
         mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.DROOLS_BUILD_MVN_OPTS_UPSTREAM }}
-  - project: apache/incubator-kie-kogito-apps
-    build-command: 
-      current: |
-        export MVN_CMD=`bash -c "if [ '${{ env.ENABLE_DEPLOY }}' = 'true' ]; then printf 'deploy ${{ env.DEPLOY_MVN_OPTS }} ${{ env.KOGITO_APPS_DEPLOY_MVN_OPTS }}'; else printf 'install'; fi"`
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean ${{ env.MVN_CMD }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
-      upstream: |
-        mvn dependency:tree -DoutputFile=${{ env.GITHUB_WORKSPACE }}/${{ env.DEPENDENCY_TREE_FILE }} -DappendOutput=true clean install -Dquickly ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_UPSTREAM }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS_UPSTREAM }}
-      after:
-        # Make sure you add -pl into MVN_PROJECTS_EXCLUSION when adding some exclusions
-        current: |
-          export MVN_PROJECTS_EXCLUSION=""
-          echo  ${{ env.MVN_PROJECTS_EXCLUSION }}
-          mvn clean package -DskipTests -Dfull artifact:3.5.1:compare -Dcompare.fail=false -Dcompare.aggregate.only=true -Dreference.repo=file:~/.m2/repository ${{ env.MVN_PROJECTS_EXCLUSION }} ${{ env.BUILD_MVN_OPTS }} ${{ env.BUILD_MVN_OPTS_CURRENT }} ${{ env.KOGITO_APPS_BUILD_MVN_OPTS }}
-        upstream: |
-          echo "Skipping dependency tree comparison for upstream builds"
   - project: apache/incubator-kie-kogito-examples
     build-command:
       # First install the main pom

--- a/tools/zip-sources-files/BUILD
+++ b/tools/zip-sources-files/BUILD
@@ -46,12 +46,7 @@ git init .
 mvn clean install -DskipTests -Dfull -Donly.reproducible=true
 cd ..
 
-2. Build Kogito Apps:
-cd incubator-kie-kogito-apps
-mvn clean install -DskipTests -Dfull -Donly.reproducible=true -Pjitexecutor-native
-cd ..
-
-3. Build Kogito Images:
+2. Build Kogito Images:
 cd incubator-kie-kogito-images
 cekit --descriptor kogito-base-builder-image.yaml build docker --platform linux/amd64
 make build-image KOGITO_APPS_TARGET_BRANCH=main ignore_test=true image_name=kogito-data-index-ephemeral
@@ -62,7 +57,7 @@ make build-image KOGITO_APPS_TARGET_BRANCH=main ignore_test=true image_name=kogi
 make build-image KOGITO_APPS_TARGET_BRANCH=main ignore_test=true image_name=kogito-jobs-service-postgresql
 cd ..
 
-4. Build KIE Tools:
+3. Build KIE Tools:
 cd incubator-kie-tools
 git init .
 git config user.name "Builder"

--- a/tools/zip-sources-files/build.sh
+++ b/tools/zip-sources-files/build.sh
@@ -47,11 +47,6 @@ build_components() {
     mvn clean install -DskipTests -Dfull -Donly.reproducible=true
     cd ..
 
-    # Build Kogito Apps
-    cd incubator-kie-kogito-apps || exit 1
-    mvn clean install -DskipTests -Dfull -Donly.reproducible=true -Pjitexecutor-native
-    cd ..
-
     # Build Kogito Images
     cd incubator-kie-kogito-images || exit 1
     cekit --descriptor kogito-base-builder-image.yaml build docker --platform linux/amd64


### PR DESCRIPTION
Update files to reflect kogito-runtimes being merged into drools

Related PRs:
- https://github.com/apache/incubator-kie-drools/pull/6834 Merges kogito-apps into the drools repository
- https://github.com/apache/incubator-kie-kogito-apps/pull/2351 Update kogito-apps readme to show new archived state
- https://github.com/apache/incubator-kie-tools/pull/3681 Update kie-tools drools-and-kogito package to reflext changes
