### PR TITLE
[kie-issues#2285] EPIC - 10.3.x+ stream: Archive kogito-pipelines

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,4 +1,5 @@
 github:
+  description: "This repository is archived. The Kogito pipelines have been replaced by local CI and release scripts in the apache/incubator-kie and apache/incubator-kie-tools repositories."
   features:
     issues: true
   enabled_merge_buttons:

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+> [!NOTE]
+> **This repository is archived.**
+>
+> The Kogito CI/CD pipelines maintained here have been retired and replaced by local CI and release scripts
+> now living directly in the [apache/incubator-kie](https://github.com/apache/incubator-kie)
+> and [apache/incubator-kie-tools](https://github.com/apache/incubator-kie-tools) repositories.
+>
+> For CI configuration, release scripts, or to file issues, please use those repositories.
+
 # Kogito Pipelines
 
 This repository contains some of the pipelines of Kogito project.


### PR DESCRIPTION
Partially closes https://github.com/apache/incubator-kie-issues/issues/2285 by updating the readme and asf.yaml to reflect the kogito-pipelines repository being archived